### PR TITLE
Remove priority category from US template

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -9,9 +9,9 @@ assignees: ''
 
 As a [ user X ], I want to [ do Y ], so that [ I can accomplish Z ].
 
-| MoSCoW      | Priority         | Risk               | Story Points  |
-| ------------- | ------------- | ------------- | ------------- |
-|                     |                      |                      |                    |
+| MoSCoW      |  Risk               | Story Points  |
+| ------------- |------------- | ------------- |
+| Must/Should/Could/Won't have |                      |                    |
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
Removed the priority category in the value table for the user story template, as it seemed pointless considering we specify the MoSCoW value