### PR TITLE
#33 Fixed compose profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@
    > :bulb: Note that you don't have to create any account or credentials prior to this setup. It will be done automatically when you first run the containers.
 
 5. Open a terminal window in the root directory of the repository (UInnovate).
-6. Run `docker compose up` to start the containers.  
-   You can stop them at any time by running `docker compose stop`.
+6. Run `docker compose --profile tool up` to start the containers.  
+   You can stop them at any time by running `docker compose --profile tool stop`.
+   
+    > :bulb: Note that the pgadmin container will only be targeted by a docker compose command if you specify `--profile tool` as shown above. Otherwise, only the PostgreSQL and the PostgREST containers will be affected. Leaving it out can become handy if you try to reset the database, but you don't want to lose your server connection on pgadmin!  
 
 7. In a web browser window, access to localhost:5050
 8. Log in to pgAdmin with the credentials you provided in your `.env` file.

--- a/compose.yml
+++ b/compose.yml
@@ -2,8 +2,6 @@ services:
   db:
     image: postgres:latest
     container_name: db
-    profiles:
-      - system
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -31,8 +29,6 @@ services:
     image: postgrest/postgrest
     ports:
       - "3000:3000"
-    profiles:
-      - system
     environment:
       PGRST_DB_URI: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB_NAME}
       PGRST_DB_SCHEMAS: application, meta


### PR DESCRIPTION
This fixes BUG #33, where the docker compose command without specifying profile would not target any container.

Currently, the compose command logic is as follows: 

```
docker compose up/down/stop/...
```
^ Targets only the PostgreSQL and PostgREST containers ^

```
docker compose --profile tool up/down/stop/...
```
^ Targets **ALL** containers ^
I.E. adds the pgadmin container to the containers targeted by the command



Relates to #33