### PR TITLE
#65 Fix refresh script not populating properties

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -11,7 +11,6 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
     volumes:
-
       - ./init.sql:/docker-entrypoint-initdb.d/1_init.sql # Create the schemas, the custom views and the web_anon role
       - db_data:/data/postgres
     networks:

--- a/database/meta.sql
+++ b/database/meta.sql
@@ -51,11 +51,11 @@ CREATE TABLE IF NOT EXISTS meta.appconfig_properties (
 );
 -- Creating the application config values table
 CREATE TABLE IF NOT EXISTS meta.appconfig_values (
-	property TEXT,
+	id serial PRIMARY KEY,
+    property TEXT,
 	value TEXT NOT NULL,
 	"table" TEXT,
 	"column" TEXT,
-    PRIMARY KEY (property, "table", "column"),
 	FOREIGN KEY (property) 
 	REFERENCES meta.appconfig_properties(name)
 	ON DELETE CASCADE 

--- a/database/meta.sql
+++ b/database/meta.sql
@@ -62,12 +62,6 @@ CREATE TABLE IF NOT EXISTS meta.appconfig_values (
 	ON UPDATE CASCADE
 );
 
--- Copying the properties from the csv file into the proper table
-COPY meta.appconfig_properties("name", description, value_type, default_value)
-FROM '/dataFiles/appconfig_properties.csv'
-DELIMITER ','
-CSV HEADER;
-
 -- USAGE 
 GRANT USAGE ON SCHEMA meta TO web_anon;
 

--- a/refresh_database.sh
+++ b/refresh_database.sh
@@ -12,6 +12,7 @@ META_FILE="./database/meta.sql"
 SCHEMA_FILE="./database/application.sql"
 DATA_FILE="./database/data.sql"
 LOG_FILE="./database/refresh_log.txt"
+APPCONFIG_PROPERTIES_FILE="./dataFiles/appconfig_properties.csv"
 
 # method to check existence of files
 check_file_existence() {
@@ -34,6 +35,12 @@ for SQL_FILE in $META_FILE $SCHEMA_FILE $DATA_FILE; do
     echo "Executing $SQL_FILE..." | tee -a $LOG_FILE
     docker exec -i db psql -U $DB_USER -d $DB_NAME -a -f - < $SQL_FILE 2>&1 | tee -a $LOG_FILE
 done
+
+# Populating appconfig_properties tables with data in appconfig_properties.csv
+if [[ -f $APPCONFIG_PROPERTIES_FILE ]]; then
+    echo "Populating appconfig_properties with $APPCONFIG_PROPERTIES_FILE" | tee -a $LOG_FILE
+    cat $APPCONFIG_PROPERTIES_FILE | docker exec -i db psql -U $DB_USER -d $DB_NAME -a -c "\copy meta.appconfig_properties FROM STDIN delimiter ',' csv" | tee -a $LOG_FILE 
+fi
 
 # Log completion time
 echo "Database refresh completed at $(date)" | tee -a $LOG_FILE


### PR DESCRIPTION
Added a couple of lines so that the refresh script will populate the `appconfig_properties` table with the values inside `appconfig_properties.csv`.

I also took this PR as an opportunity to slightly modify the primary key of the appconfig_values table so that it better reflects the way reading/writing should be working.