### PR TITLE
Removed vi.mock('axios') in TableConfigTab.tsx

### DIFF
--- a/UInnovateApp/src/components/settingsPage/TableConfigTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/TableConfigTab.tsx
@@ -15,7 +15,6 @@ import { useConfig } from "../../contexts/ConfigContext";
 import ConfigProperty from "../../virtualmodel/ConfigProperties";
 import { ConfigValueType } from "../../contexts/ConfigContext";
 
-vi.mock('axios');
 interface TableItemProps {
 	tableName: string;
 	isVisible: boolean;


### PR DESCRIPTION
Fixes bug where an extra line was added where it wasn't supposed to 