### PR TITLE
Fixed Warning

### DIFF
--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -86,7 +86,7 @@ const TableListView: React.FC<TableListViewProps> = ({
                       <label>
                         {columns.map((column, colIdx) => {
                           return (
-                            <div className="row-details">
+                            <div key={column + 'div'} className="row-details">
                               <label key={column + colIdx}>{column}</label>
                               <input
                                 type="text"


### PR DESCRIPTION
A warning for each child in a list should have a unique key for the rendering of 'TableListView'. Added a key to a div under a column mapping to fix warning. 