### PR TITLE
93 Adding the List Modal on Add Row

### DIFF
--- a/UInnovateApp/src/components/AddRowPopup.tsx
+++ b/UInnovateApp/src/components/AddRowPopup.tsx
@@ -79,7 +79,12 @@ const AddRowPopup = ({
       aria-describedby="modal-modal-description"
     >
       <Box sx={style}>
-        <Typography variant="h5">Adding a new Enumerated type</Typography>
+        {/* Verify if we need a modal for the Enum Type or the List Type to display the title */}
+        {table.table_display_type === "enum" ? (
+          <Typography variant="h5">Adding a new Enumerated type</Typography>
+        ) : (
+          <Typography variant="h5">Adding a new List type</Typography>
+        )}
         <div className="addEnum">
           {columns.map((column: Column, idx) => {
             return (

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -13,6 +13,7 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
 import { LocalizationProvider } from "@mui/x-date-pickers";
 import { Switch, Button, Typography } from "@mui/material";
+import AddRowPopup from "./AddRowPopup";
 
 interface TableListViewProps {
   table: Table;
@@ -38,6 +39,7 @@ const TableListView: React.FC<TableListViewProps> = ({
   const [columns, setColumns] = useState<Column[]>([]);
   const [rows, setRows] = useState<Row[] | undefined>([]);
   const { config } = useConfig();
+  const [isPopupVisible, setIsPopupVisible] = useState<boolean>(false);
 
   useEffect(() => {
     const getRows = async () => {
@@ -170,6 +172,11 @@ const TableListView: React.FC<TableListViewProps> = ({
     setOpenPanel(true);
   };
 
+  // Function to open the popup
+  const handleAddRowClick = () => {
+    setIsPopupVisible(true);
+  };
+
   return (
     <div>
       <div
@@ -180,9 +187,16 @@ const TableListView: React.FC<TableListViewProps> = ({
         }}
       >
         <div>
-          <Button style={buttonStyle} variant="contained">
-            Add Row
+          <Button style={buttonStyle} variant="contained" onClick={() => handleAddRowClick()}>
+            Add {table.table_name}
           </Button>
+          {isPopupVisible && (
+            <AddRowPopup
+              onClose={() => setIsPopupVisible(false)}
+              table={table}
+              columns={table.getRequiredColumns()}
+            />
+          )}
         </div>
         <div>
           {scripts?.map((script) => {

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -187,14 +187,18 @@ const TableListView: React.FC<TableListViewProps> = ({
         }}
       >
         <div>
-          <Button style={buttonStyle} variant="contained" onClick={() => handleAddRowClick()}>
+          <Button
+            style={buttonStyle}
+            variant="contained"
+            onClick={() => handleAddRowClick()}
+          >
             Add {table.table_name}
           </Button>
           {isPopupVisible && (
             <AddRowPopup
               onClose={() => setIsPopupVisible(false)}
               table={table}
-              columns={table.getRequiredColumns()}
+              columns={table.getColumns()}
             />
           )}
         </div>

--- a/UInnovateApp/src/virtualmodel/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/VMD.tsx
@@ -395,6 +395,12 @@ export class Table {
     return this.columns;
   }
 
+  // Method to get the table's required columns
+  // return type : Column[]
+  getRequiredColumns() {
+    return this.columns.filter((column) => column.reqOnCreate === true);
+  }
+
   // Method to get all visible columns from the table object
   // return type : Column[]
   getVisibleColumns() {
@@ -443,11 +449,13 @@ export class Column {
   column_name: string;
   column_type: string;
   is_visible: boolean;
+  reqOnCreate: boolean;
 
   constructor(column_name: string) {
     this.column_name = column_name;
     this.column_type = "";
     this.is_visible = true;
+    this.reqOnCreate = false;
   }
 
   // Method to set the column type


### PR DESCRIPTION
Using a similar logic to adding a new enumerated type with the corresponding modal, a new modal was added for the List View. The methods to get the columns with the reqOnCreate have been established in the VMD, however since our tables haven't been updated with the comments, the list view just maps to all the existing columns. Eventually, the proper logic will be added to only render the columns that are true on creation from the Use Case.

## Preview of Button : Add Rentals
<img width="901" alt="image" src="https://github.com/WillTrem/UInnovate/assets/74876532/71d4e66e-46d2-4796-843c-6233080e7f2e">

## Preview of the Modal
<img width="916" alt="image" src="https://github.com/WillTrem/UInnovate/assets/74876532/7c2d3f35-4a9f-4fd0-bfe1-5ecf353c8f99">
