### PR TITLE
99-Editable-Fields-in-the-Details-View

### DIFF
--- a/UInnovateApp/src/components/SlidingComponents/LookUpTableDetails.tsx
+++ b/UInnovateApp/src/components/SlidingComponents/LookUpTableDetails.tsx
@@ -1,0 +1,32 @@
+import TableComponent from "react-bootstrap/Table";
+import vmd, { Table, Column } from "../virtualmodel/VMD";
+import { DataAccessor, Row } from "../virtualmodel/DataAccessor";
+import React, { useState, useEffect } from "react";
+import SlidingPanel from "react-sliding-side-panel";
+import "react-sliding-side-panel/lib/index.css";
+import { useConfig } from "../contexts/ConfigContext";
+import { ConfigProperty } from "../virtualmodel/ConfigProperties";
+import { NumericFormat } from "react-number-format";
+import { DateField } from "@mui/x-date-pickers/DateField";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import dayjs from "dayjs";
+import { LocalizationProvider } from "@mui/x-date-pickers";
+import { Switch, Button, Typography } from "@mui/material";
+import AddRowPopup from "./AddRowPopup";
+import { as, c, s } from "vitest/dist/reporters-5f784f42.js";
+import { current } from "@reduxjs/toolkit";
+
+interface TableListViewProps {
+    table: Table;
+  }
+
+  const LookUpTableDetails: React.FC<TableListViewProps> = ({table}:TableListViewProps) => {
+
+
+return ( 
+    <>
+    </>
+);
+  }
+
+  export default LookUpTableDetails;

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -45,9 +45,6 @@ const TableListView: React.FC<TableListViewProps> = ({
   const [isPopupVisible, setIsPopupVisible] = useState<boolean>(false);
   const [inputValues, setInputValues] = useState<Row>({});
   const [currentPrimaryKey, setCurrentPrimaryKey] =  useState<string | null>(null);
-  const [shouldUpdateRows, setShouldUpdateRows] = useState(true);
-
-
 
 
 
@@ -81,12 +78,9 @@ const TableListView: React.FC<TableListViewProps> = ({
 
       setColumns(attributes);
       setRows(filteredRows);
-      setShouldUpdateRows(false);
     };
-    if (shouldUpdateRows) {
     getRows();
-    }
-  }, [ shouldUpdateRows]);
+  }, [table]);
 
   const [openPanel, setOpenPanel] = useState(false);
   const [currentRow, setCurrentRow] = useState<Row>(new Row({}));
@@ -153,10 +147,12 @@ const TableListView: React.FC<TableListViewProps> = ({
     );
     data_accessor.updateRow();
     setOpenPanel(false);
-    setShouldUpdateRows(true);
   };
 
+  // const ReadPrimaryKeyandValue = (Primekey:string, PrimekeyValue:string) => {
   
+  // }
+
 
 
   useEffect(() => {

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -197,18 +197,23 @@ const TableListView: React.FC<TableListViewProps> = ({
       } else if (columnDisplayType.value == "number") {
         return (
           <NumericFormat
-            value={(currentRow.row[column.column_name] as number) || ""}
-            allowLeadingZeros
-            thousandSeparator=","
-            readOnly
+          readOnly={column.is_editable === false ? true : false}
+          placeholder={String(currentRow.row[column.column_name]) || ""}
+          name={column.column_name}
+          type="text"
+          style={inputStyle}
+          onChange={handleInputChange}
           />
         );
       } else if (columnDisplayType.value == "longtext") {
         return (
           <textarea
-            placeholder="Type anything…"
-            value={(currentRow.row[column.column_name] as string) || ""}
-            readOnly
+          readOnly={column.is_editable === false ? true : false}
+          placeholder={String(currentRow.row[column.column_name]) || ""}
+          name={column.column_name}
+          type="text"
+          style={inputStyle}
+          onChange={handleInputChange}
           />
         );
       } else if (columnDisplayType.value == "datetime") {

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -127,11 +127,9 @@ const TableListView: React.FC<TableListViewProps> = ({
   };
 
   const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    console.log(table.columns)
     
     event.preventDefault();
 
-    console.log(currentPrimaryKey)
     const schema = vmd.getTableSchema(table.table_name);
     if (!schema) {
       console.error("Schema not found");
@@ -147,7 +145,6 @@ const TableListView: React.FC<TableListViewProps> = ({
       currentPrimaryKey as string,
       storedPrimaryKeyValue as string
     );
-    console.log(data_accessor)
     data_accessor.updateRow();
     setOpenPanel(false);
   };

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -47,38 +47,38 @@ const TableListView: React.FC<TableListViewProps> = ({
   const [currentPrimaryKey, setCurrentPrimaryKey] =  useState<string | null>(null);
 
 
+  const getRows = async () => {
+    const attributes = table.getVisibleColumns();
+    const schema = vmd.getTableSchema(table.table_name);
 
+    if (!schema) {
+      return;
+    }
+
+    const data_accessor: DataAccessor = vmd.getRowsDataAccessor(
+      schema.schema_name,
+      table.table_name
+    );
+
+    const lines = await data_accessor.fetchRows();
+
+    // Filter the rows to only include the visible columns
+    const filteredRows = lines?.map((row) => {
+      const filteredRowData: { [key: string]: string | number | boolean } =
+        {};
+      attributes.forEach((column) => {
+        filteredRowData[column.column_name] = row[column.column_name];
+      });
+      return new Row(filteredRowData);
+    });
+
+    setColumns(attributes);
+    setRows(filteredRows);
+  };
 
 
   useEffect(() => {
-    const getRows = async () => {
-      const attributes = table.getVisibleColumns();
-      const schema = vmd.getTableSchema(table.table_name);
-
-      if (!schema) {
-        return;
-      }
-
-      const data_accessor: DataAccessor = vmd.getRowsDataAccessor(
-        schema.schema_name,
-        table.table_name
-      );
-
-      const lines = await data_accessor.fetchRows();
-
-      // Filter the rows to only include the visible columns
-      const filteredRows = lines?.map((row) => {
-        const filteredRowData: { [key: string]: string | number | boolean } =
-          {};
-        attributes.forEach((column) => {
-          filteredRowData[column.column_name] = row[column.column_name];
-        });
-        return new Row(filteredRowData);
-      });
-
-      setColumns(attributes);
-      setRows(filteredRows);
-    };
+    
     getRows();
   }, [table]);
 
@@ -145,7 +145,7 @@ const TableListView: React.FC<TableListViewProps> = ({
       currentPrimaryKey as string,
       storedPrimaryKeyValue as string
     );
-    data_accessor.updateRow();
+    data_accessor.updateRow().then(() => getRows());
     setOpenPanel(false);
   };
 

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -45,6 +45,9 @@ const TableListView: React.FC<TableListViewProps> = ({
   const [isPopupVisible, setIsPopupVisible] = useState<boolean>(false);
   const [inputValues, setInputValues] = useState<Row>({});
   const [currentPrimaryKey, setCurrentPrimaryKey] =  useState<string | null>(null);
+  const [shouldUpdateRows, setShouldUpdateRows] = useState(true);
+
+
 
 
 
@@ -78,9 +81,12 @@ const TableListView: React.FC<TableListViewProps> = ({
 
       setColumns(attributes);
       setRows(filteredRows);
+      setShouldUpdateRows(false);
     };
+    if (shouldUpdateRows) {
     getRows();
-  }, [table]);
+    }
+  }, [ shouldUpdateRows]);
 
   const [openPanel, setOpenPanel] = useState(false);
   const [currentRow, setCurrentRow] = useState<Row>(new Row({}));
@@ -147,12 +153,10 @@ const TableListView: React.FC<TableListViewProps> = ({
     );
     data_accessor.updateRow();
     setOpenPanel(false);
+    setShouldUpdateRows(true);
   };
 
-  // const ReadPrimaryKeyandValue = (Primekey:string, PrimekeyValue:string) => {
   
-  // }
-
 
 
   useEffect(() => {

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -187,7 +187,7 @@ const TableListView: React.FC<TableListViewProps> = ({
         return (
           <input
             readOnly={column.is_editable === false ? true : false}
-            placeholder={(currentRow.row[column.column_name] as string) || ""}
+            placeholder={String(currentRow.row[column.column_name]) || ""}
             name={column.column_name}
             type="text"
             style={inputStyle}

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -44,7 +44,6 @@ const TableListView: React.FC<TableListViewProps> = ({
   const [isPopupVisible, setIsPopupVisible] = useState<boolean>(false);
   const [inputValues, setInputValues] = useState<Row>({});
   const [currentPrimaryKey, setCurrentPrimaryKey] =  useState<string | null>(null);
-  const [currentPrimaryKeyValue, setCurrentPrimaryKeyValue] = useState<string | null>(null);
 
 
 
@@ -119,7 +118,6 @@ const TableListView: React.FC<TableListViewProps> = ({
     if (nonEditableColumn) {
       setCurrentPrimaryKey(nonEditableColumn.column_name);
       }
-    setCurrentPrimaryKeyValue("go")
 
     setInputValues((prevInputValues) => ({
       ...prevInputValues,
@@ -150,8 +148,6 @@ const TableListView: React.FC<TableListViewProps> = ({
     );
     console.log(data_accessor)
     data_accessor.updateRow();
-    setCurrentPrimaryKey(null);
-    setCurrentPrimaryKeyValue(null);
     setOpenPanel(false);
   };
 
@@ -181,11 +177,7 @@ const TableListView: React.FC<TableListViewProps> = ({
 
 
       if (
-        column.is_editable == false &&
-        currentPrimaryKey !== column.column_name &&
-        currentPrimaryKeyValue !== (currentRow.row[column.column_name] as string) &&
-        currentPrimaryKey !== null &&
-        currentPrimaryKeyValue !== null) {
+        column.is_editable == false) {
 
         localStorage.setItem("currentPrimaryKeyValue", currentRow.row[column.column_name]);
 
@@ -241,7 +233,7 @@ const TableListView: React.FC<TableListViewProps> = ({
       }
     };
     setInputField(() => newInputField as (column: Column) => JSX.Element);
-  }, [currentRow, columns, config, table, currentPrimaryKey, currentPrimaryKeyValue]);
+  }, [currentRow, columns, config, table]);
 
   // Function to save the current row
   const handleOpenPanel = (row: Row) => {
@@ -362,7 +354,9 @@ const TableListView: React.FC<TableListViewProps> = ({
           </Button>
           </div>
         </div>
+        
       </SlidingPanel>
+      
     </div>
   );
 };

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -16,6 +16,7 @@ import { Switch, Button, Typography } from "@mui/material";
 import AddRowPopup from "./AddRowPopup";
 import { as, c, s } from "vitest/dist/reporters-5f784f42.js";
 import { current } from "@reduxjs/toolkit";
+import LookUpTableDetails from "./SlidingComponents/LookUpTableDetails";
 
 interface TableListViewProps {
   table: Table;
@@ -354,7 +355,9 @@ const TableListView: React.FC<TableListViewProps> = ({
           </Button>
           </div>
         </div>
-        
+      
+        <LookUpTableDetails table={table} />
+
       </SlidingPanel>
       
     </div>

--- a/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
+++ b/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
@@ -12,7 +12,7 @@ type LookUpTableProps = {
   table:Table;
 }
 
-const LookUpTable: React.FC<LookUpTableProps> = ({table,}:LookUpTableProps) => {
+const LookUpTable: React.FC<LookUpTableProps> = ({table}:LookUpTableProps) => {
 
   
 

--- a/UInnovateApp/src/tests/tablelistview.test.tsx
+++ b/UInnovateApp/src/tests/tablelistview.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import TableListView from "../components/TableListView";
 import { MemoryRouter } from "react-router-dom";
 import { Column, Table } from "../virtualmodel/VMD";
@@ -36,5 +36,23 @@ describe("TableListView component", () => {
     // Wait for the table to be rendered
     const tableElement = await screen.findByRole("table");
     expect(tableElement).toBeInTheDocument();
+
+
+    it("opens and closes the sliding panel", () => {
+      // Render the component
+      render(<TableListView table={table} /* props */ />);
+  
+      // Check if the sliding panel is not open by default
+      expect(screen.queryByText("Details")).not.toBeInTheDocument();
+  
+      // Find the button that opens the sliding panel and simulate a click event
+      const openButton = screen.getAllByRole('button',);
+      fireEvent.click(openButton[1]);
+  
+      // Check if the sliding panel is now open
+      expect(screen.getByText("LookUpTableDetails")).toBeInTheDocument();
+  
+    
   });
+});
 });

--- a/UInnovateApp/src/virtualmodel/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/VMD.tsx
@@ -485,6 +485,18 @@ export class Table {
   setHasDetailsView(has_details_view: boolean) {
     this.has_details_view = has_details_view;
   }
+
+  // Method to get the table's url
+  // return type : string
+  getURL() {
+    return this.url;
+  }
+
+  // Method to set the table's url
+  // return type : void
+  setURL(url: string) {
+    this.url = url;
+  }
 }
 
 

--- a/UInnovateApp/src/virtualmodel/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/VMD.tsx
@@ -170,7 +170,7 @@ class VirtualModelDefinition {
         }
 
         // Add column to the table object
-        table.addColumn(new Column(data.column), data.references_table);
+        table.addColumn(new Column(data.column), data.references_table, data.is_editable);
       });
       this.data_fetched = true;
     } catch (error) {
@@ -318,6 +318,27 @@ class VirtualModelDefinition {
     }
   }
 
+  // Method to return a data accessor object to update a row in a table
+  // return type : DataAccessor
+  getUpdateRowDataAccessorView(schema_name: string, table_name: string, row: Row, primarykey:string, primarykeyvalue:string) {
+    const schema = this.getSchema(schema_name);
+    const table = this.getTable(schema_name, table_name);
+
+    if (schema && table) {
+      return new DataAccessor(
+        `${table.url}?${primarykey}=eq.${primarykeyvalue}`, // PostgREST URL for updating a row from its id
+        {
+          Prefer: "return=representation",
+          "Content-Type": "application/json",
+          "Content-Profile": schema_name,
+        },
+        undefined,
+        row
+      );
+    } else {
+      throw new Error("Schema or table does not exist");
+    }
+  }
   // Method to return a data accessor object to upsert a set of rows in a table
   // return type : DataAccessor
   getUpsertDataAccessor(
@@ -382,11 +403,14 @@ export class Table {
     this.has_details_view = true;
     this.columns = [];
     this.url = "http://localhost:3000/" + table_name;
+    
   }
 
   // Method to add a new column to the table object
-  addColumn(column: Column, references_table: string) {
+  addColumn(column: Column, references_table: string, is_editable: boolean) {
     column.setReferenceTable(references_table);
+    column.setEditability(is_editable);
+    
     this.columns.push(column);
   }
 
@@ -470,6 +494,7 @@ export class Column {
   is_visible: boolean;
   reqOnCreate: boolean;
   references_table: string;
+  is_editable: boolean;
 
 
   constructor(column_name: string) {
@@ -478,6 +503,7 @@ export class Column {
     this.is_visible = true;
     this.reqOnCreate = false;
     this.references_table = "";
+    this.is_editable = false;
   }
 
   // Method to set the column type
@@ -503,6 +529,19 @@ export class Column {
   getReferenceTable() {
     return this.references_table;
   }
+
+
+  // Method to set the column's editability
+  // return type : void
+  setEditability(is_editable: boolean) {
+    this.is_editable = is_editable;
+  }
+
+  // Method to get the column's editability
+  // return type : boolean
+  getEditability() {
+    return this.is_editable;
+  }
 }
 
 export enum TableDisplayType {
@@ -516,6 +555,7 @@ interface ColumnData {
   table: string;
   column: string;
   references_table: string;
+  is_editable: boolean;
 }
 
 // Defining ConfigData interface for type checking when calling /appconfig_values with the API

--- a/database/meta.sql
+++ b/database/meta.sql
@@ -33,29 +33,57 @@ CREATE OR REPLACE VIEW meta.constraints ("schema_name", "table_name", "column_na
 
 
 -- Creating the columns view
-CREATE OR REPLACE VIEW meta.columns ("schema", "table", "column", "references_table") AS 
+CREATE OR REPLACE VIEW meta.columns ("schema", "table", "column", "references_table", "is_editable") AS 
 (
-    SELECT c.table_schema, c.table_name, c.column_name,  rc.referenced_table
+     
+     SELECT 
+        c.table_schema, 
+        c.table_name, 
+        c.column_name,  
+        rc.referenced_table,
+        CASE WHEN c.column_name = pk.table_pkey THEN false ELSE true END AS is_editable
     FROM information_schema.columns AS c
     LEFT JOIN 
     (
-        SELECT cl.relname as referee_table,  att.attname as referee_column, cl2.relname as referenced_table, att2.attname as referenced_column FROM pg_catalog.pg_constraint as co
-		LEFT JOIN pg_catalog.pg_class as cl
-		ON co.conrelid = cl.oid
-		LEFT JOIN pg_catalog.pg_class as cl2
-		ON co.confrelid = cl2.oid
-		LEFT JOIN pg_catalog.pg_attribute as att
-		ON cl.oid = att.attrelid AND ARRAY[att.attnum] = co.conkey
-		LEFT JOIN pg_catalog.pg_attribute as att2
-		ON cl2.oid = att2.attrelid AND ARRAY[att2.attnum] = co.confkey
-		WHERE contype = 'f'
+        SELECT 
+            cl.relname as referee_table,  
+            att.attname as referee_column, 
+            cl2.relname as referenced_table, 
+            att2.attname as referenced_column 
+        FROM pg_catalog.pg_constraint as co
+        LEFT JOIN pg_catalog.pg_class as cl
+        ON co.conrelid = cl.oid
+        LEFT JOIN pg_catalog.pg_class as cl2
+        ON co.confrelid = cl2.oid
+        LEFT JOIN pg_catalog.pg_attribute as att
+        ON cl.oid = att.attrelid AND ARRAY[att.attnum] = co.conkey
+        LEFT JOIN pg_catalog.pg_attribute as att2
+        ON cl2.oid = att2.attrelid AND ARRAY[att2.attnum] = co.confkey
+        WHERE contype = 'f'
     ) AS rc
     ON c.column_name = rc.referee_column AND c.table_name != rc.referenced_table
+    -- New LEFT JOIN for primary key references
+    LEFT JOIN 
+    (
+        SELECT 
+            cl.relname as table_name,  
+            att.attname as table_pkey
+        FROM pg_catalog.pg_constraint as co
+        LEFT JOIN pg_catalog.pg_class as cl
+        ON co.conrelid = cl.oid
+        LEFT JOIN pg_catalog.pg_attribute as att
+        ON cl.oid = att.attrelid AND ARRAY[att.attnum] = co.conkey
+        WHERE contype = 'p'
+    ) AS pk
+    ON c.table_name = pk.table_name
+    
     WHERE c.table_name IN 
     (
         SELECT "table" FROM meta.tables
     )
     ORDER BY c.table_schema, c.table_name
+	
+	 
 ) ;
 
 


### PR DESCRIPTION
Related to US #99 

## Main changes

### Details fields are now editable 
When looking at the detail view, the fields that are not primary keys are editable and can be saved. After a refresh, the updated fields will be displayed. 

What it looks like on the detail page with no edits yet. 
![image](https://github.com/WillTrem/UInnovate/assets/92006009/5d199eb0-8e6c-4fed-985c-e752dc1c265b)

What it looks like when you edit the fields that can be edited.  
![image](https://github.com/WillTrem/UInnovate/assets/92006009/e045c077-4e01-4653-bbab-4263e0a6aced)

Once you save what the results look like after a refresh and reselect of the table.
![image](https://github.com/WillTrem/UInnovate/assets/92006009/f0793fc6-d986-435e-8f2a-afd2f76cb985)

### New column in Columns View 
There is now a new column called "is_editable" which checks for each row whether the column_name is a primary key, if it is then the field will be set to false, otherwise, it's set to true. 

## Minor changes 
-Added to the column class object in the VMD by adding an is_editable as a new value and a new update row Accessor specifically for the details view. 
-Added tests to the tablelistview for the sliding panel
-Added a new SlidingPanelComponent folder with LookUpTableDetails in it.


