### PR TITLE
137 - Integrate user management system into db

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,7 @@
 POSTGRES_USER=<your postgresql username>
 POSTGRES_PASSWORD=<your postgresql password>
 POSTGRES_DB_NAME=<your postgresql db name>
+JWT_SECRET= #RUN generate_jwt_secret.sh !!
 
 # PGADMIN 
 PGADMIN_DEFAULT_EMAIL=<your pgadmin email>

--- a/Dockerfile.postgres
+++ b/Dockerfile.postgres
@@ -1,0 +1,12 @@
+FROM postgres:16
+RUN apt-get update && apt-get install -y curl
+
+
+RUN apt-get -y install make git postgresql-server-dev-16 postgresql-16-pgtap
+
+RUN git clone https://github.com/michelp/pgjwt.git && \
+    cd pgjwt && \
+    make && \
+    make install
+
+# COPY ./pgjwt/pgjwt--0.0.1.sql /docker-entrypoint-initdb.d/

--- a/Dockerfile.postgres
+++ b/Dockerfile.postgres
@@ -1,6 +1,6 @@
 FROM postgres:16
 RUN apt-get update && apt-get install -y curl
-
+ARG JWT_SECRET
 
 RUN apt-get -y install make git postgresql-server-dev-16 postgresql-16-pgtap
 
@@ -8,5 +8,6 @@ RUN git clone https://github.com/michelp/pgjwt.git && \
     cd pgjwt && \
     make && \
     make install
-
-# COPY ./pgjwt/pgjwt--0.0.1.sql /docker-entrypoint-initdb.d/
+    
+# Sets the value of the config parameter 'custom.jwt_secret' to the value of the environment variable JWT_SECRET in .env
+RUN echo "custom.jwt_secret = '${JWT_SECRET}'" >> /usr/share/postgresql/postgresql.conf.sample 

--- a/compose.yml
+++ b/compose.yml
@@ -2,7 +2,9 @@ services:
   db:
     build:
       context: .
-      dockerfile: Dockerfile.postgres 
+      dockerfile: Dockerfile.postgres
+      args:
+        - JWT_SECRET
     container_name: db
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
@@ -10,10 +12,11 @@ services:
       POSTGRES_DB: ${POSTGRES_DB_NAME} # Default database's name
       PGDATA: /data/postgres
       PGUSER: web_anon
+      JWT_SECRET: ${JWT_SECRET}
     ports:
       - "127.0.0.1:5432:5432"
     volumes:
-      - ./init.sql:/docker-entrypoint-initdb.d/1_init.sql # Create the schemas, the custom views and the web_anon role
+      - ./init.sh:/docker-entrypoint-initdb.d/init.sh # Create the schemas, the custom views and the web_anon role
       - db_data:/data/postgres
     networks:
       - backend
@@ -39,10 +42,11 @@ services:
     ports:
       - "3000:3000"
     environment:
-      PGRST_DB_URI: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB_NAME}
+      PGRST_DB_URI: postgres://authenticator:${JWT_SECRET}@db:5432/${POSTGRES_DB_NAME} #The authenticator roles has the JWT_SECRET as password (set in init.sh)
       PGRST_DB_SCHEMAS: application, meta
       PGRST_OPENAPI_SERVER_PROXY_URI: http://127.0.0.1:3000
       PGRST_DB_ANON_ROLE: web_anon
+      PGRST_JWT_SECRET: ${JWT_SECRET}
     depends_on:
       - db
     networks:

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,8 @@
 services:
   db:
-    image: postgres:16
+    build:
+      context: .
+      dockerfile: Dockerfile.postgres 
     container_name: db
     environment:
       POSTGRES_USER: ${POSTGRES_USER}

--- a/database/auth.sql
+++ b/database/auth.sql
@@ -1,0 +1,228 @@
+-- SCHEMA AND TABLES CREATION
+CREATE SCHEMA IF NOT EXISTS authentication;
+
+CREATE TABLE IF NOT EXISTS 
+authentication.users (
+	email text primary key check (email ~* '^.+@.+\..+$'),
+	first_name text,
+	last_name text,
+	role name not null check (length(role)<512),
+	password text check (length(password) < 512),
+	is_active bool not null
+);
+
+CREATE TABLE IF NOT EXISTS 
+authentication.user_schema_access (
+	email text REFERENCES authentication.users,
+	schema text -- Add trigger to verify if schema exists in schema view
+);
+
+-- TRIGGER to ensure the role from the authentication.users table is an actual database role
+CREATE OR REPLACE FUNCTION 
+authentication.check_role_exists() returns trigger as $$
+begin
+	if not exists(select 1 from pg_roles as r where r.rolname = new.role) then
+		raise foreign_key_violation using message = 
+			'invalid database role: ' || new.role;
+		return null;
+	end if;
+	return new;
+end
+$$ language plpgsql;
+
+drop trigger if exists ensure_user_role_exists on authentication.users;
+create constraint trigger ensure_user_role_exists
+	after insert or update on authentication.users
+	for each row
+	execute procedure authentication.check_role_exists();
+
+-- TRIGGER to ensure the schemas from user_schema_access are existing schemas
+
+CREATE OR REPLACE FUNCTION 
+authentication.check_schema_exists() returns trigger as $$
+begin
+	if not exists(select 1 from meta.schemas as s where s.schema = new.schema) then
+		raise foreign_key_violation using message = 
+			'invalid schema : ' || new.role;
+		return null;
+	end if;
+	return new;
+end
+$$ language plpgsql;
+
+drop trigger if exists ensure_schema_exists on authentication.user_schema_access; 
+create constraint trigger ensure_schema_exists
+	after insert or update on authentication.user_schema_access
+	for each row
+	execute procedure authentication.check_schema_exists();
+
+-- TRIGGER to keep the passwords encrypted with pgcrypto
+create extension if not exists pgcrypto;
+
+create or replace function
+authentication.encrypt_password() returns trigger as $$
+begin
+	if tg_op = 'INSERT' or new.password <> old.password then
+		new.password = crypt(new.password, gen_salt('bf'));
+	end if;
+	return new;
+end
+$$ language plpgsql;
+
+drop trigger if exists encrypt_password on authentication.users;
+create trigger encrypt_password
+	before insert or update on authentication.users
+	for each row
+	execute procedure authentication.encrypt_password();
+
+-- FUNCTION that returns the database role for a user if email and passwords match
+create or replace function
+authentication.user_role(email text, password text) returns name
+	language plpgsql
+	as $$
+begin
+	return (
+		select role from authentication.users
+		where users.email = user_role.email
+			and users.password = crypt(user_role.password, users.password)
+	);
+end;
+$$;
+
+-- ROLES
+
+DROP ROLE IF EXISTS administrator;
+DROP ROLE IF EXISTS configurator;
+DROP ROLE IF EXISTS "user";
+DROP ROLE IF EXISTS authenticator;
+
+create role "user" noinherit;
+
+-- Granting all on application schemas and tables to user role
+DO
+$$
+DECLARE
+   schema_name text;
+   table_record record;
+BEGIN
+   FOR schema_name IN (
+       SELECT "schema" 
+       FROM meta.schemas
+       WHERE "schema" LIKE 'app%'
+   )
+   LOOP
+      EXECUTE format('GRANT ALL ON SCHEMA %I TO "user";', schema_name);
+	   FOR table_record IN (
+		   SELECT "table" 
+		   FROM meta.tables 
+		   WHERE meta.tables.schema = schema_name  -- replace with your schema name
+	   )
+	   LOOP
+		  EXECUTE format('GRANT ALL ON TABLE %I.%I TO "user";', schema_name, table_record.table);
+	   END LOOP;
+   END LOOP;
+END
+$$ LANGUAGE plpgsql;
+
+GRANT USAGE ON SCHEMA meta TO "user";
+GRANT SELECT ON TABLE meta.appconfig_properties to "user";
+GRANT SELECT ON TABLE meta.appconfig_values to "user";
+GRANT SELECT ON TABLE meta.scripts to "user";
+GRANT SELECT ON TABLE meta.schemas to "user";
+GRANT SELECT ON TABLE meta.tables to "user";
+GRANT SELECT ON TABLE meta.columns to "user";
+GRANT SELECT ON TABLE meta.constraints to "user";
+
+
+create role configurator;
+grant "user" to configurator;
+
+GRANT ALL ON SCHEMA meta TO "user";
+GRANT ALL ON TABLE meta.appconfig_properties to "user";
+GRANT ALL ON TABLE meta.appconfig_values to "user";
+GRANT ALL ON TABLE meta.scripts to "user";
+GRANT ALL ON TABLE meta.schemas to "user";
+GRANT ALL ON TABLE meta.tables to "user";
+GRANT ALL ON TABLE meta.columns to "user";
+GRANT ALL ON TABLE meta.constraints to "user";
+
+create role administrator; 
+grant configurator to administrator;
+-- ADD user management-related capabilities HERE
+
+create role authenticator LOGIN NOINHERIT NOCREATEDB NOCREATEROLE NOSUPERUSER;
+grant "user" to authenticator;
+grant configurator to authenticator;
+grant administrator to authenticator;
+grant web_anon to authenticator;
+
+-- JWT TOKENS
+
+-- Generating a random 32 characters long database secret for jwt 
+DO
+$$
+DECLARE
+   secret text;
+BEGIN
+   SELECT encode(gen_random_bytes(16), 'hex') INTO secret;
+   EXECUTE format('ALTER DATABASE uinnovate_test_db SET "app.jwt_secret" TO %L', secret);
+END
+$$;
+
+-- Generating JWT token using pgjwt
+create extension if not exists pgjwt;
+
+create TYPE authentication.jwt_token AS (
+	token text
+);
+
+-- Function to test the generation of jwt tokens
+create or replace function meta.jwt_test() RETURNS authentication.jwt_token AS $$
+	select sign(
+		row_to_json(r), current_setting('app.jwt_secret')
+	) as token
+	from (
+		select
+		'test_role'::text as role, -- sets the role
+		extract(epoch from now())::integer + 300 as exp -- sets the expiration of the token in 5 min
+	)r;
+$$ language sql security definer;
+
+-- FUNCTION login, in the meta schema to be accessible to any user
+drop type if exists authentication.jwt_token cascade;
+create type authentication.jwt_token as (
+	token text
+);
+
+create or replace function 
+meta.login(email text, password text) returns authentication.jwt_token as $$
+declare 
+	_role name;
+	result authentication.jwt_token;
+begin
+	-- check email & password
+	select authentication.user_role(email, password) into _role;
+	if _role is null then
+		raise invalid_password using message = 'invalid email or password';
+	end if;
+	
+	-- signs the jwt token
+	select sign(
+		row_to_json(r), current_setting('app.jwt_secret')
+	) as token
+	from (
+		select _role as role, login.email as email,
+		extract(epoch from now())::integer + 60*60 as exp 
+	) as r
+	into result;
+	
+	return result;
+end;
+$$  language plpgsql security definer;
+
+grant execute on function meta.login(text, text) to web_anon;
+
+
+-- TO REMOVE AT SOME POINT - Creates a test administrator account for dev purposes
+insert into authentication.users(email, first_name, last_name, password, is_active, role)
+values ('test@test.com', 'test', 'admin', 'test123', true, 'administrator');

--- a/database/auth.sql
+++ b/database/auth.sql
@@ -1,260 +1,283 @@
 -- SCHEMA AND TABLES CREATION
 CREATE SCHEMA IF NOT EXISTS authentication;
 
-CREATE TABLE IF NOT EXISTS 
-authentication.users (
-	email text primary key check (email ~* '^.+@.+\..+$'),
+CREATE TABLE IF NOT EXISTS authentication.users (
+	email text PRIMARY KEY CHECK (email ~* '^.+@.+\..+$'),
 	first_name text,
 	last_name text,
-	role name not null check (length(role)<512),
-	password text check (length(password) < 512),
-	is_active bool not null
+role name NOT NULL CHECK (length(role) < 512),
+PASSWORD text CHECK (length(PASSWORD) < 512),
+is_active bool NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS 
-meta.user_schema_access (
+CREATE TABLE IF NOT EXISTS meta.user_schema_access (
 	email text REFERENCES authentication.users,
 	schema text -- Add trigger to verify if schema exists in schema view
 );
 
 -- TRIGGER to ensure the role from the authentication.users table is an actual database role
-CREATE OR REPLACE FUNCTION 
-authentication.check_role_exists() returns trigger as $$
-begin
-	if not exists(select 1 from pg_roles as r where r.rolname = new.role) then
-		raise foreign_key_violation using message = 
-			'invalid database role: ' || new.role;
-		return null;
-	end if;
-	return new;
-end
-$$ language plpgsql;
+CREATE OR REPLACE FUNCTION authentication.check_role_exists() RETURNS TRIGGER AS $$ BEGIN IF NOT EXISTS(
+		SELECT 1
+		FROM pg_roles AS r
+		WHERE r.rolname = new.role
+	) THEN raise foreign_key_violation USING message = 'invalid database role: ' || new.role;
+RETURN NULL;
+END IF;
+RETURN new;
+END $$ language plpgsql;
 
-drop trigger if exists ensure_user_role_exists on authentication.users;
-create constraint trigger ensure_user_role_exists
-	after insert or update on authentication.users
-	for each row
-	execute procedure authentication.check_role_exists();
+DROP TRIGGER IF EXISTS ensure_user_role_exists ON authentication.users;
+CREATE CONSTRAINT TRIGGER ensure_user_role_exists
+AFTER
+INSERT
+	OR
+UPDATE ON authentication.users FOR each ROW EXECUTE PROCEDURE authentication.check_role_exists();
 
 -- TRIGGER to ensure the schemas from user_schema_access are existing schemas
+CREATE OR REPLACE FUNCTION meta.check_schema_exists() RETURNS TRIGGER AS $$ BEGIN IF NOT EXISTS(
+		SELECT 1
+		FROM meta.schemas AS s
+		WHERE s.schema = new.schema
+	) THEN raise foreign_key_violation USING message = 'invalid schema : ' || new.role;
+RETURN NULL;
+END IF;
+RETURN new;
+END $$ language plpgsql;
 
-CREATE OR REPLACE FUNCTION 
-meta.check_schema_exists() returns trigger as $$
-begin
-	if not exists(select 1 from meta.schemas as s where s.schema = new.schema) then
-		raise foreign_key_violation using message = 
-			'invalid schema : ' || new.role;
-		return null;
-	end if;
-	return new;
-end
-$$ language plpgsql;
-
-drop trigger if exists ensure_schema_exists on meta.user_schema_access; 
-create constraint trigger ensure_schema_exists
-	after insert or update on meta.user_schema_access
-	for each row
-	execute procedure meta.check_schema_exists();
+DROP TRIGGER IF EXISTS ensure_schema_exists ON meta.user_schema_access;
+CREATE CONSTRAINT TRIGGER ensure_schema_exists
+AFTER
+INSERT
+	OR
+UPDATE ON meta.user_schema_access FOR each ROW EXECUTE PROCEDURE meta.check_schema_exists();
 
 -- TRIGGER to keep the passwords encrypted with pgcrypto
-create extension if not exists pgcrypto;
+CREATE extension IF NOT EXISTS pgcrypto;
 
-create or replace function
-authentication.encrypt_password() returns trigger as $$
-begin
-	if tg_op = 'INSERT' or new.password <> old.password or old.password IS NULL then
-		new.password = crypt(new.password, gen_salt('bf'));
-	end if;
-	return new;
-end
-$$ language plpgsql;
+CREATE OR REPLACE FUNCTION authentication.encrypt_password() RETURNS TRIGGER AS $$ BEGIN IF tg_op = 'INSERT'
+	OR new.password <> old.password
+	OR old.password IS NULL THEN new.password = crypt(new.password, gen_salt('bf'));
+END IF;
+RETURN new;
+END $$ language plpgsql;
 
-drop trigger if exists encrypt_password on authentication.users;
-create trigger encrypt_password
-	before insert or update on authentication.users
-	for each row
-	execute procedure authentication.encrypt_password();
+DROP TRIGGER IF EXISTS encrypt_password ON authentication.users;
+CREATE TRIGGER encrypt_password before
+INSERT
+	OR
+UPDATE ON authentication.users FOR each ROW EXECUTE PROCEDURE authentication.encrypt_password();
 
 -- FUNCTION that returns the database role for a user if email and passwords match
-create or replace function
-authentication.user_role(email text, password text) returns name
-	language plpgsql
-	as $$
-begin
-	return (
-		select role from authentication.users
-		where users.email = user_role.email
-			and users.password = crypt(user_role.password, users.password)
+CREATE OR REPLACE FUNCTION authentication.user_role(email text, PASSWORD text) RETURNS name language plpgsql AS $$ BEGIN RETURN (
+		SELECT role
+		FROM authentication.users
+		WHERE users.email = user_role.email
+			AND users.password = crypt(user_role.password, users.password)
 	);
-end;
+END;
 $$;
 
--- ROLES
+-- JWT TOKENS
+-- Generating JWT token using pgjwt
+CREATE extension IF NOT EXISTS pgjwt;
 
+CREATE TYPE authentication.jwt_token AS (token text);
+
+-- Function to test the generation of jwt tokens
+CREATE OR REPLACE FUNCTION meta.jwt_test() RETURNS authentication.jwt_token AS $$
+SELECT sign(
+		row_to_json(r),
+		current_setting('custom.jwt_secret')
+	) AS token
+FROM (
+		SELECT 'test_role'::text AS role,
+			-- sets the role
+			extract(
+				epoch
+				FROM NOW()
+			)::integer + 300 AS exp -- sets the expiration of the token in 5 min
+	) r;
+$$ language SQL SECURITY DEFINER;
+
+-- FUNCTION LOGIN, in the meta schema to be accessible to any user
+DROP TYPE IF EXISTS authentication.jwt_token CASCADE;
+CREATE TYPE authentication.jwt_token AS (token text);
+
+CREATE OR REPLACE FUNCTION meta.login(email text, PASSWORD text) RETURNS authentication.jwt_token AS $$
+DECLARE _role name;
+result authentication.jwt_token;
+BEGIN -- check email & password
+SELECT authentication.user_role(email, PASSWORD) INTO _role;
+IF _role IS NULL THEN raise invalid_password USING message = 'invalid email or password';
+END IF;
+-- signs the jwt token
+SELECT sign(
+		row_to_json(r),
+		current_setting('custom.jwt_secret')
+	) AS token
+FROM (
+		SELECT _role AS role,
+			login.email AS email,
+			extract(
+				epoch
+				FROM NOW()
+			)::integer + 60 * 60 AS exp
+	) AS r INTO result;
+RETURN result;
+END;
+$$ language plpgsql SECURITY DEFINER;
+
+
+
+-- FUNCTION CREATE USER, for administrators to create the users in the database before they can sign up 
+CREATE OR REPLACE FUNCTION meta.create_user(email text, role name) RETURNS SETOF integer AS $$ BEGIN
+INSERT INTO authentication.users(email, role, is_active)
+VALUES (email, role, TRUE);
+RETURN;
+END;
+$$ language plpgsql SECURITY DEFINER;
+REVOKE EXECUTE ON FUNCTION meta.create_user(TEXT, NAME)
+FROM public;
+
+
+-- FUNCTION for users to SIGNUP given an administrator previously created a user in the database for them
+CREATE OR REPLACE FUNCTION meta.signup(
+		email text,
+		PASSWORD text,
+		first_name text,
+		last_name text
+	) RETURNS setof integer AS $$ BEGIN -- 	Verify if the user has been created by an administrator prior
+	IF NOT EXISTS (
+		SELECT users.email
+		FROM authentication.users
+		WHERE users.email = signup.email
+	) THEN raise exception USING message = format(
+		'User %L was not found. Please ensure an administrator has created a corresponding user in the system before trying to sign up.',
+		signup.email
+	);
+ELSE -- 		Verify if the user has a password (i.e. if it already signed up)
+IF EXISTS (
+	SELECT users.email
+	FROM authentication.users
+	WHERE users.email = signup.email
+		AND users.password IS NOT NULL
+) THEN raise exception USING message = format(
+	'User %L has already been signed up.',
+	signup.email
+);
+UPDATE authentication.users
+SET PASSWORD = signup.password,
+	first_name = signup.first_name,
+	last_name = signup.last_name
+WHERE users.email = signup.email;
+END IF;
+END IF;
+RETURN;
+END $$ language plpgsql SECURITY DEFINER;
+
+-- ROLES
+-- TODO: Move the role definitions in a separate sql file
 DROP ROLE IF EXISTS administrator;
 DROP ROLE IF EXISTS configurator;
 DROP ROLE IF EXISTS "user";
 
-create role "user" noinherit;
+CREATE role "user" noinherit;
 
 -- Granting all on application schemas and tables to user role
-DO
-$$
-DECLARE
-   schema_name text;
-   table_record record;
-BEGIN
-   FOR schema_name IN (
-       SELECT "schema" 
-       FROM meta.schemas
-       WHERE "schema" LIKE 'app%'
-   )
-   LOOP
-      EXECUTE format('GRANT ALL ON SCHEMA %I TO "user";', schema_name);
-	   FOR table_record IN (
-		   SELECT "table" 
-		   FROM meta.tables 
-		   WHERE meta.tables.schema = schema_name  -- replace with your schema name
-	   )
-	   LOOP
-		  EXECUTE format('GRANT ALL ON TABLE %I.%I TO "user";', schema_name, table_record.table);
-	   END LOOP;
-   END LOOP;
-END
-$$ LANGUAGE plpgsql;
+DO $$
+DECLARE schema_name text;
+table_record record;
+BEGIN FOR schema_name IN (
+	SELECT "schema"
+	FROM meta.schemas
+	WHERE "schema" LIKE 'app%'
+) LOOP EXECUTE format('GRANT ALL ON SCHEMA %I TO "user";', schema_name);
+FOR table_record IN (
+	SELECT "table"
+	FROM meta.tables
+WHERE meta.tables.schema = schema_name -- replace with your schema name
+) LOOP EXECUTE format(
+	'GRANT ALL ON TABLE %I.%I TO "user";',
+	schema_name,
+	table_record.table
+);
+END LOOP;
+END LOOP;
+END $$ LANGUAGE plpgsql;
 
 GRANT USAGE ON SCHEMA meta TO "user";
-GRANT SELECT ON TABLE meta.appconfig_properties to "user";
-GRANT SELECT ON TABLE meta.appconfig_values to "user";
-GRANT SELECT ON TABLE meta.scripts to "user";
-GRANT SELECT ON TABLE meta.schemas to "user";
-GRANT SELECT ON TABLE meta.tables to "user";
-GRANT SELECT ON TABLE meta.columns to "user";
-GRANT SELECT ON TABLE meta.constraints to "user";
-GRANT SELECT ON TABLE meta.user_schema_access to "user";
+GRANT SELECT ON TABLE meta.appconfig_properties TO "user";
+GRANT SELECT ON TABLE meta.appconfig_values TO "user";
+GRANT SELECT ON TABLE meta.scripts TO "user";
+GRANT SELECT ON TABLE meta.schemas TO "user";
+GRANT SELECT ON TABLE meta.tables TO "user";
+GRANT SELECT ON TABLE meta.columns TO "user";
+GRANT SELECT ON TABLE meta.constraints TO "user";
+GRANT SELECT ON TABLE meta.user_schema_access TO "user";
 
 
-create role configurator;
-grant "user" to configurator;
+CREATE role configurator;
+GRANT "user" TO configurator;
 
 GRANT ALL ON SCHEMA meta TO configurator;
-GRANT ALL ON TABLE meta.appconfig_properties to configurator;
-GRANT ALL ON TABLE meta.appconfig_values to configurator;
-GRANT ALL ON TABLE meta.scripts to configurator;
-GRANT ALL ON TABLE meta.schemas to configurator;
-GRANT ALL ON TABLE meta.tables to configurator;
-GRANT ALL ON TABLE meta.columns to configurator;
-GRANT ALL ON TABLE meta.constraints to configurator;
-GRANT ALL ON TABLE meta.user_schema_access to configurator;
+GRANT ALL ON TABLE meta.appconfig_properties TO configurator;
+GRANT ALL ON TABLE meta.appconfig_values TO configurator;
+GRANT ALL ON TABLE meta.scripts TO configurator;
+GRANT ALL ON TABLE meta.schemas TO configurator;
+GRANT ALL ON TABLE meta.tables TO configurator;
+GRANT ALL ON TABLE meta.columns TO configurator;
+GRANT ALL ON TABLE meta.constraints TO configurator;
+GRANT ALL ON TABLE meta.user_schema_access TO configurator;
 
 
-create role administrator; 
-grant configurator to administrator;
+CREATE role administrator;
+GRANT configurator TO administrator;
+
+GRANT EXECUTE ON FUNCTION meta.create_user(text, name) TO administrator;
+
 -- ADD user management-related capabilities HERE
+GRANT EXECUTE ON FUNCTION meta.login(text, text) TO web_anon;
+GRANT EXECUTE ON FUNCTION meta.signup TO web_anon;
 
-grant "user" to authenticator;
-grant configurator to authenticator;
-grant administrator to authenticator;
-grant web_anon to authenticator;
-
--- JWT TOKENS
+GRANT "user" TO authenticator;
+GRANT configurator TO authenticator;
+GRANT administrator TO authenticator;
+GRANT web_anon TO authenticator;
 
 
--- Generating JWT token using pgjwt
-create extension if not exists pgjwt;
-
-create TYPE authentication.jwt_token AS (
-	token text
-);
-
--- Function to test the generation of jwt tokens
-create or replace function meta.jwt_test() RETURNS authentication.jwt_token AS $$
-	select sign(
-		row_to_json(r), current_setting('custom.jwt_secret')
-	) as token
-	from (
-		select
-		'test_role'::text as role, -- sets the role
-		extract(epoch from now())::integer + 300 as exp -- sets the expiration of the token in 5 min
-	)r;
-$$ language sql security definer;
-
--- FUNCTION login, in the meta schema to be accessible to any user
-drop type if exists authentication.jwt_token cascade;
-create type authentication.jwt_token as (
-	token text
-);
-
-create or replace function 
-meta.login(email text, password text) returns authentication.jwt_token as $$
-declare 
-	_role name;
-	result authentication.jwt_token;
-begin
-	-- check email & password
-	select authentication.user_role(email, password) into _role;
-	if _role is null then
-		raise invalid_password using message = 'invalid email or password';
-	end if;
-	
-	-- signs the jwt token
-	select sign(
-		row_to_json(r), current_setting('custom.jwt_secret')
-	) as token
-	from (
-		select _role as role, login.email as email,
-		extract(epoch from now())::integer + 60*60 as exp 
-	) as r
-	into result;
-	
-	return result;
-end;
-$$  language plpgsql security definer;
-
-grant execute on function meta.login(text, text) to web_anon;
-
--- FUNCTION CREATE USER, for administrators to create the users in the database before they can sign up 
-create or replace function 
-meta.create_user(email text, role name) 
-returns SETOF integer as $$
-begin
-	INSERT INTO authentication.users(email, role, is_active) VALUES
-	(email, role, true);
-	RETURN;
-end;
-$$ language plpgsql security definer;
-REVOKE EXECUTE ON FUNCTION meta.create_user(TEXT, NAME) FROM public;
-grant execute on function meta.create_user(text, name) to administrator;
-
--- FUNCTION for users to SIGNUP given an administrator previously created a user in the database for them
-create or replace function meta.signup(email text, password text, first_name text, last_name text)
-returns setof integer as $$
-begin
--- 	Verify if the user has been created by an administrator prior
-	if NOT EXISTS (SELECT users.email FROM authentication.users WHERE users.email = signup.email ) then
-		raise exception using message = format('User %L was not found. Please ensure an administrator has created a corresponding user in the system before trying to sign up.', signup.email);
-	else
--- 		Verify if the user has a password (i.e. if it already signed up)
-		if EXISTS (SELECT users.email FROM authentication.users WHERE users.email = signup.email and users.password IS NOT NULL ) then
-			raise exception using message = format('User %L has already been signed up.', signup.email);
-			UPDATE authentication.users
-			SET password = signup.password, first_name = signup.first_name, last_name = signup.last_name
-			WHERE users.email = signup.email;
-		end if;
-	
-	end if;
-	RETURN;
-end
-$$ language plpgsql security definer;
-
-grant execute on function meta.signup to web_anon;
-
--- TO REMOVE AT SOME POINT - Creates a test administrator account for dev purposes
-insert into authentication.users(email, first_name, last_name, password, is_active, role)
-values ('admin@test.com', 'test', 'admin', 'admin123', true, 'administrator'),
-('config@test.com', 'test', 'admin', 'config123', true, 'configurator'),
-('user@test.com', 'test', 'admin', 'user123', true, 'user')
-ON CONFLICT (email) DO NOTHING; -- If you change anything here after they've been created once in the database, it won't have any effect. You need to remove them first from the database.
-
-NOTIFY pgrst, 'reload schema';
-
+-- TO REMOVE AT SOME POINT - Creates test users with all 3 roles for dev purposes
+INSERT INTO authentication.users(
+		email,
+		first_name,
+		last_name,
+		PASSWORD,
+		is_active,
+		role
+	)
+VALUES (
+		'admin@test.com',
+		'test',
+		'admin',
+		'admin123',
+		TRUE,
+		'administrator'
+	),
+	(
+		'config@test.com',
+		'test',
+		'admin',
+		'config123',
+		TRUE,
+		'configurator'
+	),
+	(
+		'user@test.com',
+		'test',
+		'admin',
+		'user123',
+		TRUE,
+		'user'
+	) ON CONFLICT (email) DO NOTHING;
+-- If you change anything here after they've been created once in the database, it won't have any effect. You need to remove them first from the database.
+NOTIFY pgrst,
+'reload schema';

--- a/generate_jwt_secret.sh
+++ b/generate_jwt_secret.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# generate a 32 characters random secret
+export LC_CTYPE=C
+jwt_secret="$(< /dev/random tr -dc A-Za-z0-9 | head -c32)" 
+
+# output it in .env (append if doesn't exist and updates if exists)
+if grep -q "JWT_SECRET=" .env; then	
+	sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$jwt_secret/" ".env"
+else
+	echo "JWT_SECRET=$jwt_secret" >> .env
+fi
+
+echo "New JWT secret generated. Please restart your docker containers."

--- a/init.sh
+++ b/init.sh
@@ -1,2 +1,11 @@
-# Restoring the application data
-pg_restore -U ${POSTGRES_USER} -d ${POSTGRES_DB} /dumps/uinnovate-test-db-dump.backup -n application -c --if-exists --no-owner --no-privileges 
+#!/bin/bash
+
+# Creates the authenticator and anonymous roles so that postgrest can be used
+psql -U ${POSTGRES_USER} -d ${POSTGRES_DB}  <<-END
+	CREATE ROLE web_anon nologin;
+	DO \$\$
+    BEGIN
+        EXECUTE format('CREATE ROLE authenticator LOGIN PASSWORD %L NOINHERIT NOCREATEDB NOCREATEROLE NOSUPERUSER;', current_setting('custom.jwt_secret'));
+    END;
+    \$\$ LANGUAGE plpgsql;
+END

--- a/refresh_database.sh
+++ b/refresh_database.sh
@@ -30,6 +30,7 @@ DATA_FILE="./database$USECASE_FOLDER/data.sql"
 META_DATA_FILE="./database$USECASE_FOLDER/meta_data.sql"
 LOG_FILE="./database/refresh_log.txt"
 APPCONFIG_PROPERTIES_FILE="./dataFiles/appconfig_properties.csv"
+AUTH_FILE="./database/auth.sql"
 
 # method to check existence of files
 check_file_existence() {
@@ -48,7 +49,7 @@ check_file_existence $DATA_FILE
 echo "Database refresh started at $(date)" | tee -a $LOG_FILE
 
 # Recreate meta tables and views, schema (drop and create tables), and data (insert new data)
-for SQL_FILE in $META_FILE $SCHEMA_FILE $DATA_FILE $META_DATA_FILE; do
+for SQL_FILE in $META_FILE $SCHEMA_FILE $DATA_FILE $META_DATA_FILE $AUTH_FILE; do
     echo "Executing $SQL_FILE..." | tee -a $LOG_FILE
     docker exec -i db psql -U $DB_USER -d $DB_NAME -a -f - < $SQL_FILE 2>&1 | tee -a $LOG_FILE
 done


### PR DESCRIPTION
## Major changes
### The authentication and user management system described in the proposal (see #89 ) was implemented.
- Functions for **login**, **creating user** and **signup** have been added.
- Login returns a JWT token which is then used to make authenticated requests (based on your role)
- Roles have been added:
    - **Administrator**
    - **Configurator**
    - **User**
- Basic authorization from role has been set, which will be improved in further stories.
- The anonymous role (used when you don't authenticate your request) still has all the permissions assigned previously for dev purposes. This will however change at some point.
- 3 users are created from the SQL file, 1 of each role. Their credentials can be found at the complete bottom of the auth.sql file.
- Various validation functions & triggers

### Setting up for authentication:
1. Run `generate_jwt_secret.sh`. This should add a JWT_SECRET line in your .env file.
2. Re-build the PostgreSQL docker image with the command `docker compose build db`.
3. Start your docker containers. 
4. Run `refresh_database.sh`.
5. You should be all set! :)

### Using JWT to make authenticated requests
1. Obtain your JWT token by calling the `login` database function:
![using_auth_1](https://github.com/WillTrem/UInnovate/assets/64431699/bb48fbb4-43f0-4de1-9816-efaababca2d0)
2. Use your JWT token in the 'Authorization' header to execute any requests authenticated as the user you logged in with:
![using_auth_2](https://github.com/WillTrem/UInnovate/assets/64431699/4dcacd22-1e7b-4a78-9bee-08be8596ccda)

### :warning: Notes about the current state of authentication
- At the moment, authentication doesn't have a real purpose yet. It will once the login is implemented in the actual platform.
- In the future, we won't need to call the functions directly through the API. The web app will do that automatically, we'll be able to login/signup/create users from the UI.

## Minor changes 
- The compose file now uses init.sh instead of init.sql as the entry point for the database container. This is to allow for the authentication secrets to be integrated into the database.  