### PR TITLE
added fix for git file pathing bug

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
-new .gitattributes file specifies the file endings to be in unix