### PR TITLE
144 test reports deployment onto PostGOAT

### DIFF
--- a/.github/workflows/tests-reports.yml
+++ b/.github/workflows/tests-reports.yml
@@ -2,8 +2,9 @@ name: Deploy Tests Reports
 
 on:
   push:
+    path: './UInnovateApp/coverage/**'
     branches:
-      - 144-test-reports-deployment
+      - main
 
 jobs:
   deploy_tests_reports:

--- a/.github/workflows/tests-reports.yml
+++ b/.github/workflows/tests-reports.yml
@@ -1,0 +1,38 @@
+name: Deploy Tests Reports
+
+on:
+  push:
+    branches:
+      - 144-tests-reports
+
+jobs:
+  deploy_tests_reports:
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./
+
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
+
+    steps:
+    - name: Checkout UInnovate repository
+      uses: actions/checkout@v2
+
+    - name: Check files
+      working-directory: ./UInnovateApp
+      run: |
+        echo "Contents of coverage directory:"
+        ls -l coverage
+
+    - name: Copy files to another repository
+      uses: nkoppel/push-files-to-another-repository@v1.1.2      
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.POSTGOAT_WEBSITE_REPOSITORY_DEPLOYMENT_SECRET }}
+      with:
+        source-files: 'UInnovateApp/coverage/'
+        destination-username: 'MariaR001'
+        destination-repository: 'PostGOAT'
+        destination-branch: 'main'
+        commit-email: 'ma_iv@live.concordia.ca'

--- a/.github/workflows/tests-reports.yml
+++ b/.github/workflows/tests-reports.yml
@@ -3,7 +3,7 @@ name: Deploy Tests Reports
 on:
   push:
     branches:
-      - 144-tests-reports
+      - 144-test-reports-deployment
 
 jobs:
   deploy_tests_reports:


### PR DESCRIPTION
This workflow file pushes all tests reports/coverage onto the PostGOAT repo (website) with every merge to main, if there are changes in the coverage folder. 

If you go to the PostGOAT repo, there now is a coverage folder that holds all our test reports.

Note: This test report has to be further modified in the website (PostGOAT repo) so it looks nicer. 