### PR TITLE
176 import and export cron configurations

### DIFF
--- a/database/cron.sql
+++ b/database/cron.sql
@@ -7,3 +7,53 @@ ALTER POLICY cron_job_run_details_policy ON cron.job_run_details
 USING (username = current_user OR current_user = 'web_anon');
 ALTER POLICY cron_job_policy ON cron.job 
 USING (username = current_user OR current_user = 'web_anon');
+
+-- EXPORT CRON CONFIGURATIONS FUNCTION
+CREATE OR REPLACE FUNCTION cron.export_cronconfig_to_json()
+RETURNS json
+LANGUAGE plpgsql
+AS $BODY$
+DECLARE
+    cron_json json;
+BEGIN
+    SELECT COALESCE(json_agg(row_to_json(c)), '[]') INTO cron_json
+    FROM (
+        SELECT jobid, schedule, command, nodename, nodeport, database, username, active, jobname
+        FROM cron.job
+    ) c;
+
+    RETURN cron_json;
+END;
+$BODY$;
+
+-- IMPORT FUNCTIONALITY FOR CRON JOBS
+CREATE OR REPLACE FUNCTION cron.import_cronconfig_from_json(json)
+RETURNS void
+LANGUAGE plpgsql
+AS $BODY$
+DECLARE
+    cron_data json;  -- Variable to hold the JSON array of cron jobs
+    cron_row json;   -- Variable to hold each cron job row data
+BEGIN
+    cron_data := $1; -- Assign the passed JSON to cron_data
+
+    -- Assuming you want to clear the existing cron jobs and replace with new ones
+    DELETE FROM cron.job;
+
+    -- Iterate through each element in the JSON array
+    FOR cron_row IN SELECT * FROM json_array_elements(cron_data)
+    LOOP
+        -- Insert each cron job into the cron_jobs table
+        INSERT INTO cron.job (jobid, schedule, command, nodename, nodeport, database, username, active, jobname)
+        VALUES ((cron_row->>'jobid')::int, 
+                cron_row->>'schedule', 
+                cron_row->>'command', 
+                cron_row->>'nodename', 
+                (cron_row->>'nodeport')::int, 
+                cron_row->>'database', 
+                cron_row->>'username', 
+                (cron_row->>'active')::boolean, 
+                cron_row->>'jobname');
+    END LOOP;
+END;
+$BODY$;

--- a/database/cron.sql
+++ b/database/cron.sql
@@ -55,6 +55,8 @@ BEGIN
                 (cron_row->>'active')::boolean, 
                 cron_row->>'jobname');
     END LOOP;
+END;
+$BODY$;
 
 CREATE OR REPLACE FUNCTION cron.schedule_job_by_name(stored_procedure varchar, cron_schedule varchar)
 RETURNS varchar

--- a/scripting/export_cron_config.sh
+++ b/scripting/export_cron_config.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+source ../.env
+
+# Define the output JSON file
+output_file="cron_configurations.json"
+
+DB_CONTAINER="db"
+DB_USER=$POSTGRES_USER
+DB_PASS=$POSTGRES_PASSWORD
+DB_NAME=$POSTGRES_DB_NAME
+docker exec -i $DB_CONTAINER psql -tA -U "$DB_USER" -d "$DB_NAME" -c "SELECT cron.export_cronconfig_to_json();" > "$output_file"
+
+echo "Cron configurations have been exported to $output_file"

--- a/scripting/import_cron_config.sh
+++ b/scripting/import_cron_config.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+source ../.env
+
+# Define the input JSON file
+input_file="cron_configurations.json"
+
+DB_CONTAINER="db"
+DB_USER=$POSTGRES_USER
+DB_PASS=$POSTGRES_PASSWORD
+DB_NAME=$POSTGRES_DB_NAME
+
+# Read the JSON file content
+json_data=$(<"$input_file")
+
+docker exec -i $DB_CONTAINER psql -tA -U "$DB_USER" -d "$DB_NAME" -c "SELECT cron.import_cronconfig_from_json('$json_data')"
+
+echo "Cron configurations have been imported from $input_file"


### PR DESCRIPTION
export script allows cron configs to be exported to json files.

import script allows the importing and inserting into the database for cron jobs.

both working, will need to merge into main and will probably need to solve conflicts before making PR.