### PR TITLE
170 stand alone details view

### DIFF
--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -32,13 +32,7 @@ const buttonStyle = {
   width: "fit-content",
 };
 
-const inputStyle = {
-  display: "flex",
-  flexDirection: "column", // This will make the children (input elements) stack vertically
-  alignItems: "flex-start",
-  width: "65%",
 
-};
 
 const TableListView: React.FC<TableListViewProps> = ({
   table,
@@ -138,6 +132,15 @@ const TableListView: React.FC<TableListViewProps> = ({
     getScripts();
   }, []);
 
+
+  const inputStyle = {
+    display: "flex",
+    flexDirection: "column", 
+    alignItems: "flex-start",
+    width: table.stand_alone_details_view ? '80%' : "120%",
+  
+  };
+  const tableStyle = table.stand_alone_details_view ? 'form-group-stand-alone' : 'form-group';
   //For when order changes
   const handleOrderchange = (event: SelectChangeEvent) => {
     setOrderValue(event.target.value as string);
@@ -193,7 +196,7 @@ const TableListView: React.FC<TableListViewProps> = ({
     data_accessor.updateRow().then(() => getRows());
     setInputValues({});
     setOpenPanel(false);
-    
+
   };
 
   // const ReadPrimaryKeyandValue = (Primekey:string, PrimekeyValue:string) => {
@@ -295,8 +298,8 @@ const TableListView: React.FC<TableListViewProps> = ({
     if (!table.has_details_view) {
       return;
     }
-    if(table.stand_alone_details_view){
-      console.log("No Stand Alone Details View "+ table.table_name)
+    if (table.stand_alone_details_view) {
+      console.log("No Stand Alone Details View " + table.table_name)
     }
     setOpenPanel(true);
   };
@@ -310,7 +313,7 @@ const TableListView: React.FC<TableListViewProps> = ({
     if (showTable) {
       setTimeout(() => {
         setShowTable(false);
-      }, 1000); // Adjust the delay as needed
+      }, 1000);
     }
   }, [openPanel]);
 
@@ -434,15 +437,14 @@ const TableListView: React.FC<TableListViewProps> = ({
       <SlidingPanel
         type={"right"}
         isOpen={openPanel}
-        size={50}
+        size={table.stand_alone_details_view ? 100 : 50}
         panelContainerClassName="panel-container"
         backdropClicked={() => setOpenPanel(false)}
       >
         <div className="form-panel-container">
           <Typography variant="h5">Details</Typography>
           <form>
-            <div className="form-group">
-              <label>
+            <div className={tableStyle}>
                 {columns.map((column, colIdx) => {
                   return (
                     <div key={column.column_name} className="row-details">
@@ -453,7 +455,6 @@ const TableListView: React.FC<TableListViewProps> = ({
                     </div>
                   );
                 })}
-              </label>
             </div>
           </form>
           <div>
@@ -475,23 +476,26 @@ const TableListView: React.FC<TableListViewProps> = ({
           </div>
 
         </div>
-        {localStorage.getItem(table.table_name + "T") === null || getTable[-1] == "none"? (
-          <div></div>
-        ) : showTable ? (
-          <div style={{ paddingBottom: '2em' }}>
-            <LookUpTableDetails table={table} />
-          </div>
-        ) : (
-          <Button
-            variant="contained"
-            color="primary"
-            style={{ marginLeft: 15 }}
-            onClick={() => setShowTable(true)}
-          >
-            Show Look up Table
-          </Button>
-        )}
+        <div style={{ paddingBottom: '2em' }}>
+          {localStorage.getItem(table.table_name + "T") === null || getTable[-1] == "none" ? (
+            <div></div>
 
+          ) : showTable ? (
+            <div style={{ paddingBottom: '2em' }}>
+              <LookUpTableDetails table={table} />
+            </div>
+          ) : (
+            <Button
+              variant="contained"
+              color="primary"
+              style={{ marginLeft: 15 }}
+              onClick={() => setShowTable(true)}
+
+            >
+              Show Look up Table
+            </Button>
+          )}
+        </div>
 
       </SlidingPanel>
 

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -295,6 +295,9 @@ const TableListView: React.FC<TableListViewProps> = ({
     if (!table.has_details_view) {
       return;
     }
+    if(table.stand_alone_details_view){
+      console.log("No Stand Alone Details View "+ table.table_name)
+    }
     setOpenPanel(true);
   };
 

--- a/UInnovateApp/src/components/settingsPage/ColumnConfig.tsx
+++ b/UInnovateApp/src/components/settingsPage/ColumnConfig.tsx
@@ -36,12 +36,12 @@ export const ColumnConfig: React.FC<ColumnConfigProps> = ({
       </thead>
       <tbody>
         {attributes &&
-          attributes.map((attribute) => {
+          attributes.map((attribute, index) => {
             return (
               <ColumnConfigRow
                 column={attribute}
                 table={table}
-                key={attribute.column_name}
+                key={attribute.column_name+index}
               />
             );
           })}

--- a/UInnovateApp/src/components/settingsPage/TableConfigTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/TableConfigTab.tsx
@@ -19,7 +19,7 @@ interface TableItemProps {
 
 export const TableItem: React.FC<TableItemProps> = ({ table }) => {
   const schema = vmd.getTableSchema(table.table_name);
-  
+
 
 
   if (!schema) {
@@ -51,6 +51,13 @@ export const TableItem: React.FC<TableItemProps> = ({ table }) => {
     table.setHasDetailsView(!isVisible);
     await updateTableConfig(ConfigProperty.DETAILS_VIEW, (!isVisible).toString());
   };
+
+  const handleToggleStandAloneDetails = async () => {
+    const isVisible = table.getStandAloneDetailsView();
+    table.setStandAloneDetailsView(!isVisible);
+    await updateTableConfig(ConfigProperty.STAND_ALONE_DETAILS_VIEW, (!isVisible).toString());
+  };
+
 
   const handleDisplayTypeSelect = async (event: SelectChangeEvent<string>) => {
     const newDisplayType = event.target.value;
@@ -96,18 +103,27 @@ export const TableItem: React.FC<TableItemProps> = ({ table }) => {
             </div>
 
             <div className="details-views">
-            <span className="px-1" style={{ width: '180px' }}>Details View</span>
-            <Switch
-                  defaultChecked={table.getHasDetailsView()}
-                  onChange={handleToggleDetails}
-                  data-testid="detail-visibility-switch"
-                />
+              <span className="px-1" style={{ width: '180px' }}>Details View</span>
+              <Switch
+                checked={table.getHasDetailsView()}
+                onChange={handleToggleDetails}
+                data-testid="detail-visibility-switch"
+              />
 
-                </div>  
-              <div className="details-view">
-                <LookUpTable table={table}/>
             </div>
-            
+            <div className="details-views">
+              <span className="px-1" style={{ width: '180px' }}>Stand Alone Detail view</span>
+              <Switch
+                checked={table.getStandAloneDetailsView()}
+                onChange={handleToggleStandAloneDetails}
+                data-testid="Stand_Alone_detail-visibility-switch"
+              />
+
+            </div>
+            <div className="details-view">
+              <LookUpTable table={table} />
+            </div>
+
           </div>
         </Card.Body>
       </Card>

--- a/UInnovateApp/src/styles/TableComponent.css
+++ b/UInnovateApp/src/styles/TableComponent.css
@@ -27,9 +27,10 @@ td {
 
 .row-details {
   display: flex;
-  gap: 5px;
-  padding-top: 10px;
   flex-direction: column;
+  gap: 5px;
+  padding-top: 5px;
+  width: 40%
 }
 
 .title-panel {
@@ -45,11 +46,19 @@ td {
   padding: 1em;
 }
 
-.form-group {
+.form-group-stand-alone {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  height:120%
+  
+
+  
+}
+.form-group{
   display: flex;
   flex-direction: column;
-  align-content: flex-start;
-  align-items: stretch;
+
 }
 
 input {

--- a/UInnovateApp/src/tests/tablelistview.test.tsx
+++ b/UInnovateApp/src/tests/tablelistview.test.tsx
@@ -51,7 +51,7 @@ describe("TableListView component", () => {
       fireEvent.click(openButton[1]);
 
       // Check if the sliding panel is now open
-      expect(screen.getByText("LookUpTableDetails")).toBeInTheDocument();
+      expect(screen.getByText("Details")).toBeInTheDocument();
 
 
     });

--- a/UInnovateApp/src/virtualmodel/ConfigProperties.ts
+++ b/UInnovateApp/src/virtualmodel/ConfigProperties.ts
@@ -6,5 +6,6 @@ export enum ConfigProperty {
   DISPLAY_COLUMN_AS_CURRENCY = "display_column_as_currency",
   COLUMN_DISPLAY_TYPE = "column_display_type",
   METADATA_VIEW = "metadata_view",
-  DETAILS_VIEW = "details_view"
+  DETAILS_VIEW = "details_view",
+  STAND_ALONE_DETAILS_VIEW = "stand_alone_details_view"
 }

--- a/UInnovateApp/src/virtualmodel/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/VMD.tsx
@@ -267,7 +267,10 @@ class VirtualModelDefinition {
             break;
           case "details_view":
             table.has_details_view = config.value === "true";
-            break; 
+            break;
+          case "stand_alone_details_view":
+            table.stand_alone_details_view = config.value === "true";
+            break;
         }
       });
       this.config_data_fetched = true;
@@ -306,13 +309,13 @@ class VirtualModelDefinition {
 
   // Method to return a data accessor object to fetch rows from a table with ordering and pagination involved
   // return type : DataAccessor
-  getRowsDataAccessorForOrder(schema_name: string, table_name: string, order_by: string, Limit:number, Page:number) {
+  getRowsDataAccessorForOrder(schema_name: string, table_name: string, order_by: string, Limit: number, Page: number) {
     const schema = this.getSchema(schema_name);
     const table = this.getTable(schema_name, table_name);
     const limit = Limit.toString();
-    const page = ((Page-1)*Limit).toString();
+    const page = ((Page - 1) * Limit).toString();
     if (schema && table) {
-      return new DataAccessor(table.url+"?order="+order_by+"&limit="+limit+"&offset="+page, {
+      return new DataAccessor(table.url + "?order=" + order_by + "&limit=" + limit + "&offset=" + page, {
         "Accept-Profile": schema.schema_name,
       });
     } else {
@@ -321,12 +324,12 @@ class VirtualModelDefinition {
   }
   // Method to return a data accessor object to fetch rows from a table For Look up Table
   // return type : DataAccessor
-  getRowsDataAccessorForLookUpTable(schema_name: string, table_name: string, SearchKey: string, SearchValue:string) {
+  getRowsDataAccessorForLookUpTable(schema_name: string, table_name: string, SearchKey: string, SearchValue: string) {
     const schema = this.getSchema(schema_name);
     const table = this.getTable(schema_name, table_name);
-    
+
     if (schema && table) {
-      return new DataAccessor(table.url+ "?"+SearchKey+"=eq."+SearchValue, {
+      return new DataAccessor(table.url + "?" + SearchKey + "=eq." + SearchValue, {
         "Accept-Profile": schema.schema_name,
       });
     } else {
@@ -383,7 +386,7 @@ class VirtualModelDefinition {
 
   // Method to return a data accessor object to update a row in a table
   // return type : DataAccessor
-  getUpdateRowDataAccessorView(schema_name: string, table_name: string, row: Row, primarykey:string, primarykeyvalue:string) {
+  getUpdateRowDataAccessorView(schema_name: string, table_name: string, row: Row, primarykey: string, primarykeyvalue: string) {
     const schema = this.getSchema(schema_name);
     const table = this.getTable(schema_name, table_name);
 
@@ -503,6 +506,7 @@ export class Table {
   columns: Column[];
   url: string;
   lookup_tables: Row;
+  stand_alone_details_view: boolean;
 
   constructor(table_name: string) {
     this.table_name = table_name;
@@ -511,15 +515,16 @@ export class Table {
     this.has_details_view = true;
     this.columns = [];
     this.url = API_BASE_URL + table_name;
-    this.lookup_tables = {"-1":"none"}   ;
-    
+    this.lookup_tables = { "-1": "none" };
+    this.stand_alone_details_view = false;
+
   }
 
   // Method to add a new column to the table object
   addColumn(column: Column, references_table: string, is_editable: boolean) {
     column.setReferenceTable(references_table);
     column.setEditability(is_editable);
-    
+
     this.columns.push(column);
   }
 
@@ -618,7 +623,20 @@ export class Table {
   setLookupTables(lookup_tables: Row) {
     this.lookup_tables = lookup_tables;
   }
-  
+
+  // Method to get the table's stand alone details view
+  // return type : boolean
+  getStandAloneDetailsView() {
+    return this.stand_alone_details_view;
+  }
+
+  // Method to set the table's stand alone details view
+  // return type : void
+  setStandAloneDetailsView(stand_alone_details_view: boolean) {
+    this.stand_alone_details_view = stand_alone_details_view;
+  }
+
+
 }
 
 

--- a/database/meta_data.sql
+++ b/database/meta_data.sql
@@ -7,7 +7,8 @@ VALUES
     ('display_column_as_currency', 'Displays a column as currency type.', 'boolean', 'false'),
     ('column_display_type', 'How to display a column', 'string', 'text'),
     ('metadata_view', 'Default view when showing the metadata information of a table/column', 'boolean', 'false' ),
-    ('details_view', 'Visbility state of the details view for a table', 'boolean', 'true');
+    ('details_view', 'Visibility state of the details view for a table', 'boolean', 'true'),
+    ('stand_alone_details_view', 'Visibility state of the stand alone details view for a table', 'boolean', 'false');
     -- ADD ANY NEW CONFIG PROPERTIES HERE
 
 -- Insert the default column display typess for each  app_service_support column
@@ -15,7 +16,7 @@ INSERT INTO meta.appconfig_values (property, value, "table", "column")
 SELECT
     CFP.name, default_value, C.table, C.column
 FROM meta.columns as C, meta.appconfig_properties as CFP
-WHERE schema = ' app_service_support' AND (CFP.name != 'table_view' AND CFP.name != 'details_view');
+WHERE schema = ' app_service_support' AND (CFP.name != 'table_view' AND CFP.name != 'details_view' AND CFP.name != 'stand_alone_details_view');
 
 
 -- Insert the default column display typess for each  app_service_support table
@@ -24,7 +25,7 @@ SELECT
     CFP.name, default_value, T.table
 FROM meta.tables as T, meta.appconfig_properties as CFP
 WHERE schema = ' app_service_support' AND CFP.name = 'table_view'
-OR CFP.name = 'visible' OR CFP.name = 'metadata_view' OR CFP.name = 'details_view';
+OR CFP.name = 'visible' OR CFP.name = 'metadata_view' OR CFP.name = 'details_view' OR CFP.name = 'stand_alone_details_view';
 
 -- Insert a default script for the scripts table
 INSERT INTO meta.scripts (name, description, content, table_name)


### PR DESCRIPTION

## Only Change
Refers to US #170 


### Settings now has Stand Alone Detail view
You can now toggle the stand-alone detail view in your display table settings. Once toggled true when you click a row the whole page will be the detail view.



 