### PR TITLE
103 business logic scripts sr

### DIFF
--- a/UInnovateApp/src/components/ScriptLoadPopup.tsx
+++ b/UInnovateApp/src/components/ScriptLoadPopup.tsx
@@ -7,7 +7,7 @@ const ScriptLoadPopup = ({
   script,
 }: {
   onClose: () => void;
-  script: Row;
+  script: Row | null;
 }) => {
   const handleConfirm = () => {
     // TODO: Load script

--- a/UInnovateApp/src/components/ScriptLoadPopup.tsx
+++ b/UInnovateApp/src/components/ScriptLoadPopup.tsx
@@ -13,8 +13,6 @@ const ScriptLoadPopup = ({
     // TODO: Load script
   };
 
-  onClose();
-
   const style = {
     position: "absolute",
     margin: "auto",
@@ -30,12 +28,6 @@ const ScriptLoadPopup = ({
     p: 4,
   };
 
-  //   const labelStyle = {
-  //     display: "block",
-  //     marginBottom: 5,
-  //     color: "#000000",
-  //   };
-
   const buttonStyle = {
     marginRight: 10,
     backgroundColor: "#404040",
@@ -50,10 +42,14 @@ const ScriptLoadPopup = ({
     >
       <Box sx={style}>
         <Typography variant="h5" component="h2">
-          Load Script
+          Confirm Script Execution
         </Typography>
+        <Typography variant="subtitle1" component="h6" mb={2}>
+          Are you sure you want to execute the script "{script?.["name"]}"?
+        </Typography>
+        <Typography variant="subtitle1">Description:</Typography>
         <Typography variant="body2" component="p">
-          Are you sure you want to load the script {script["name"]}?
+          {script?.["description"]}
         </Typography>
         <div className="button-container">
           <Button

--- a/UInnovateApp/src/components/ScriptLoadPopup.tsx
+++ b/UInnovateApp/src/components/ScriptLoadPopup.tsx
@@ -1,0 +1,81 @@
+import { Modal, Box, Typography, Button } from "@mui/material";
+import "../styles/AddEnumModal.css";
+import { Row } from "../virtualmodel/DataAccessor";
+
+const ScriptLoadPopup = ({
+  onClose,
+  script,
+}: {
+  onClose: () => void;
+  script: Row;
+}) => {
+  const handleConfirm = () => {
+    // TODO: Load script
+  };
+
+  onClose();
+
+  const style = {
+    position: "absolute",
+    margin: "auto",
+    padding: 3,
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    width: "auto",
+    bgcolor: "#f1f1f1",
+    border: "2px solid #000",
+    borderRadius: 8,
+    boxShadow: 24,
+    p: 4,
+  };
+
+  //   const labelStyle = {
+  //     display: "block",
+  //     marginBottom: 5,
+  //     color: "#000000",
+  //   };
+
+  const buttonStyle = {
+    marginRight: 10,
+    backgroundColor: "#404040",
+  };
+
+  return (
+    <Modal
+      open={true}
+      onClose={onClose}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+    >
+      <Box sx={style}>
+        <Typography variant="h5" component="h2">
+          Load Script
+        </Typography>
+        <Typography variant="body2" component="p">
+          Are you sure you want to load the script {script["name"]}?
+        </Typography>
+        <div className="button-container">
+          <Button
+            variant="contained"
+            color="primary"
+            sx={buttonStyle}
+            onClick={handleConfirm}
+          >
+            Confirm
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            sx={buttonStyle}
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+        </div>
+      </Box>
+    </Modal>
+  );
+};
+
+export default ScriptLoadPopup;

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -20,6 +20,7 @@ import {
   MenuItem,
   FormControl,
   SelectChangeEvent,
+  Tooltip,
 } from "@mui/material";
 import AddRowPopup from "./AddRowPopup";
 import Pagination from "@mui/material/Pagination";
@@ -139,6 +140,7 @@ const TableListView: React.FC<TableListViewProps> = ({
   const script_table = vmd.getTable("meta", "scripts");
   const config_table = vmd.getTable("meta", "appconfig_values");
   const [scripts, setScripts] = useState<Row[] | undefined>([]);
+  const [scriptDescription, setScriptDescription] = useState<string | null>("");
   const [appConfigValues, setAppConfigValues] = useState<Row[] | undefined>([]);
   const rteRef = useRef<RichTextEditorRef>(null);
 
@@ -160,6 +162,16 @@ const TableListView: React.FC<TableListViewProps> = ({
     setScripts(filteredScripts);
   };
 
+  const handleScriptHover = async (description: string) => {
+    setScriptDescription(description);
+  };
+
+  const handleScriptHoverExit = () => {
+    setScriptDescription(null);
+  };
+
+  const handleScriptConfirmation = async (script: Row) => {};
+
   const getConfigs = async () => {
     if (!schema || !config_table) {
       throw new Error("Schema or table not found");
@@ -180,15 +192,15 @@ const TableListView: React.FC<TableListViewProps> = ({
     getConfigs();
   }, [inputValues]);
 
-
   const inputStyle = {
     display: "flex",
-    flexDirection: "column", 
+    flexDirection: "column",
     alignItems: "flex-start",
-    width: table.stand_alone_details_view ? '80%' : "120%",
-  
+    width: table.stand_alone_details_view ? "80%" : "120%",
   };
-  const tableStyle = table.stand_alone_details_view ? 'form-group-stand-alone' : 'form-group';
+  const tableStyle = table.stand_alone_details_view
+    ? "form-group-stand-alone"
+    : "form-group";
   //For when order changes
   const handleOrderchange = (event: SelectChangeEvent) => {
     setOrderValue(event.target.value as string);
@@ -475,7 +487,7 @@ const TableListView: React.FC<TableListViewProps> = ({
       return;
     }
     if (table.stand_alone_details_view) {
-      console.log("No Stand Alone Details View " + table.table_name)
+      console.log("No Stand Alone Details View " + table.table_name);
     }
     setOpenPanel(true);
   };
@@ -518,16 +530,26 @@ const TableListView: React.FC<TableListViewProps> = ({
             />
           )}
         </div>
-        <div>
+        <div className="d-flex flex-column">
+          {(scripts || []).length > 0 && <h6>Scripts</h6>}
           {scripts?.map((script) => {
             return (
-              <Button
-                key={script["id"]}
-                style={buttonStyle}
-                variant="contained"
+              <Tooltip
+                title={script["description"]}
+                open={scriptDescription === script["description"]}
+                placement="right"
               >
-                {script["btn_name"]}
-              </Button>
+                <Button
+                  key={script["id"]}
+                  style={buttonStyle}
+                  variant="contained"
+                  onClick={() => handleScriptConfirmation(script)}
+                  onMouseEnter={() => handleScriptHover(script["description"])}
+                  onMouseLeave={handleScriptHoverExit}
+                >
+                  {script["btn_name"]}
+                </Button>
+              </Tooltip>
             );
           })}
         </div>
@@ -618,16 +640,16 @@ const TableListView: React.FC<TableListViewProps> = ({
           <Typography variant="h5">Details</Typography>
           <form>
             <div className={tableStyle}>
-                {columns.map((column, colIdx) => {
-                  return (
-                    <div key={colIdx} className="row-details">
-                      <label key={column.column_name + colIdx}>
-                        {column.column_name}
-                      </label>
-                      {inputField(column)}
-                    </div>
-                  );
-                })}
+              {columns.map((column, colIdx) => {
+                return (
+                  <div key={colIdx} className="row-details">
+                    <label key={column.column_name + colIdx}>
+                      {column.column_name}
+                    </label>
+                    {inputField(column)}
+                  </div>
+                );
+              })}
             </div>
           </form>
           <div>
@@ -658,12 +680,12 @@ const TableListView: React.FC<TableListViewProps> = ({
             </Button>
           </div>
         </div>
-        <div style={{ paddingBottom: '2em' }}>
-          {localStorage.getItem(table.table_name + "T") === null || getTable[-1] == "none" ? (
+        <div style={{ paddingBottom: "2em" }}>
+          {localStorage.getItem(table.table_name + "T") === null ||
+          getTable[-1] == "none" ? (
             <div></div>
-
           ) : showTable ? (
-            <div style={{ paddingBottom: '2em' }}>
+            <div style={{ paddingBottom: "2em" }}>
               <LookUpTableDetails table={table} />
             </div>
           ) : (
@@ -672,7 +694,6 @@ const TableListView: React.FC<TableListViewProps> = ({
               color="primary"
               style={{ marginLeft: 15 }}
               onClick={() => setShowTable(true)}
-
             >
               Show Look up Table
             </Button>

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -178,6 +178,12 @@ const TableListView: React.FC<TableListViewProps> = ({
     setIsScriptPopupVisible(true);
   };
 
+  useEffect(() => {
+    if (selectedScript) {
+      handleConfirmForm();
+    }
+  }, [selectedScript]);
+
   const getConfigs = async () => {
     if (!schema || !config_table) {
       throw new Error("Schema or table not found");
@@ -550,7 +556,7 @@ const TableListView: React.FC<TableListViewProps> = ({
                   style={buttonStyle}
                   variant="contained"
                   onClick={() => {
-                    handleConfirmForm();
+                    // handleConfirmForm();
                     setSelectedScript(script);
                   }}
                   onMouseEnter={() => handleScriptHover(script["description"])}

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -43,6 +43,7 @@ import {
   RichTextEditor,
   type RichTextEditorRef,
 } from "mui-tiptap";
+import ScriptLoadPopup from "./ScriptLoadPopup";
 
 interface TableListViewProps {
   table: Table;
@@ -69,6 +70,8 @@ const TableListView: React.FC<TableListViewProps> = ({
   const [columns, setColumns] = useState<Column[]>([]);
   const [rows, setRows] = useState<Row[] | undefined>([]);
   const [isPopupVisible, setIsPopupVisible] = useState<boolean>(false);
+  const [isScriptPopupVisible, setIsScriptPopupVisible] =
+    useState<boolean>(false);
   const [inputValues, setInputValues] = useState<Row>({});
   const [currentPrimaryKey, setCurrentPrimaryKey] = useState<string | null>(
     null
@@ -170,7 +173,9 @@ const TableListView: React.FC<TableListViewProps> = ({
     setScriptDescription(null);
   };
 
-  const handleScriptConfirmation = async (script: Row) => {};
+  const handleConfirmForm = () => {
+    setIsScriptPopupVisible(true);
+  };
 
   const getConfigs = async () => {
     if (!schema || !config_table) {
@@ -534,22 +539,32 @@ const TableListView: React.FC<TableListViewProps> = ({
           {(scripts || []).length > 0 && <h6>Scripts</h6>}
           {scripts?.map((script) => {
             return (
-              <Tooltip
-                title={script["description"]}
-                open={scriptDescription === script["description"]}
-                placement="right"
-              >
-                <Button
-                  key={script["id"]}
-                  style={buttonStyle}
-                  variant="contained"
-                  onClick={() => handleScriptConfirmation(script)}
-                  onMouseEnter={() => handleScriptHover(script["description"])}
-                  onMouseLeave={handleScriptHoverExit}
+              <div>
+                <Tooltip
+                  title={script["description"]}
+                  open={scriptDescription === script["description"]}
+                  placement="right"
                 >
-                  {script["btn_name"]}
-                </Button>
-              </Tooltip>
+                  <Button
+                    key={script["id"]}
+                    style={buttonStyle}
+                    variant="contained"
+                    onClick={() => handleConfirmForm()}
+                    onMouseEnter={() =>
+                      handleScriptHover(script["description"])
+                    }
+                    onMouseLeave={handleScriptHoverExit}
+                  >
+                    {script["btn_name"]}
+                  </Button>
+                </Tooltip>
+                {isScriptPopupVisible && (
+                  <ScriptLoadPopup
+                    onClose={() => setIsScriptPopupVisible(false)}
+                    script={script}
+                  />
+                )}{" "}
+              </div>
             );
           })}
         </div>

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -144,6 +144,7 @@ const TableListView: React.FC<TableListViewProps> = ({
   const config_table = vmd.getTable("meta", "appconfig_values");
   const [scripts, setScripts] = useState<Row[] | undefined>([]);
   const [scriptDescription, setScriptDescription] = useState<string | null>("");
+  const [selectedScript, setSelectedScript] = useState<Row | null>(null);
   const [appConfigValues, setAppConfigValues] = useState<Row[] | undefined>([]);
   const rteRef = useRef<RichTextEditorRef>(null);
 
@@ -539,34 +540,36 @@ const TableListView: React.FC<TableListViewProps> = ({
           {(scripts || []).length > 0 && <h6>Scripts</h6>}
           {scripts?.map((script) => {
             return (
-              <div>
-                <Tooltip
-                  title={script["description"]}
-                  open={scriptDescription === script["description"]}
-                  placement="right"
+              <Tooltip
+                title={script["description"]}
+                open={scriptDescription === script["description"]}
+                placement="right"
+              >
+                <Button
+                  key={script["id"]}
+                  style={buttonStyle}
+                  variant="contained"
+                  onClick={() => {
+                    handleConfirmForm();
+                    setSelectedScript(script);
+                  }}
+                  onMouseEnter={() => handleScriptHover(script["description"])}
+                  onMouseLeave={handleScriptHoverExit}
                 >
-                  <Button
-                    key={script["id"]}
-                    style={buttonStyle}
-                    variant="contained"
-                    onClick={() => handleConfirmForm()}
-                    onMouseEnter={() =>
-                      handleScriptHover(script["description"])
-                    }
-                    onMouseLeave={handleScriptHoverExit}
-                  >
-                    {script["btn_name"]}
-                  </Button>
-                </Tooltip>
-                {isScriptPopupVisible && (
-                  <ScriptLoadPopup
-                    onClose={() => setIsScriptPopupVisible(false)}
-                    script={script}
-                  />
-                )}{" "}
-              </div>
+                  {script["btn_name"]}
+                </Button>
+              </Tooltip>
             );
           })}
+          {isScriptPopupVisible && selectedScript && (
+            <ScriptLoadPopup
+              onClose={() => {
+                setIsScriptPopupVisible(false);
+                setSelectedScript(null);
+              }}
+              script={selectedScript}
+            />
+          )}
         </div>
         <div>
           <FormControl size="small">

--- a/UInnovateApp/src/components/settingsPage/ScriptEditor.tsx
+++ b/UInnovateApp/src/components/settingsPage/ScriptEditor.tsx
@@ -26,6 +26,7 @@ interface ScriptEditorProps {
 }
 
 export const ScriptEditor: React.FC<ScriptEditorProps> = ({ script }) => {
+  console.log(script);
   const script_name = script["name"];
   const tables = vmd.getAllTables();
 
@@ -46,6 +47,9 @@ export const ScriptEditor: React.FC<ScriptEditorProps> = ({ script }) => {
       case "btn_name":
         updatedScript = { ...updateScript, btn_name: event.target.value };
         break;
+      case "description":
+        updatedScript = { ...updateScript, description: event.target.value };
+        break;
     }
 
     setUpdateScript(updatedScript);
@@ -64,9 +68,9 @@ export const ScriptEditor: React.FC<ScriptEditorProps> = ({ script }) => {
       <Card>
         <Card.Body>
           <Card.Title>Script: {script_name}</Card.Title>
-          <div className="config-pane">
-            <div className="d-flex flex-row align-items-center">
-              <span className="px-3">Button Name</span>
+          <div className="config-pane mt-3">
+            <div className="d-flex flex-column align-items-start">
+              <h6>Button Name</h6>
               <TextField
                 defaultValue={script["btn_name"]}
                 onChange={(event) =>
@@ -93,40 +97,54 @@ export const ScriptEditor: React.FC<ScriptEditorProps> = ({ script }) => {
               </FormHelperText>
             </FormControl>
           </div>
-          <div style={{ display: "flex", flexDirection: "row" }}>
-            <div style={{ display: "flex", flexDirection: "column" }}>
-              <IconButton onClick={() => setIsEditing(!isEditing)}>
-                <EditIcon />
-              </IconButton>
-              <IconButton
-                onClick={() => {
-                  handleChange(
-                    { target: { value: content } } as SelectChangeEvent,
-                    "content"
-                  );
-                  setIsEditing(false);
+          <div className="d-flex flex-column align-items-start mb-5">
+            <h6>Description</h6>
+            <TextField
+              multiline
+              fullWidth
+              defaultValue={script["description"]}
+              onChange={(event) =>
+                handleChange(event as SelectChangeEvent, "description")
+              }
+            ></TextField>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <h6>Content</h6>
+            <div style={{ display: "flex", flexDirection: "row" }}>
+              <div style={{ display: "flex", flexDirection: "column" }}>
+                <IconButton onClick={() => setIsEditing(!isEditing)}>
+                  <EditIcon />
+                </IconButton>
+                <IconButton
+                  onClick={() => {
+                    handleChange(
+                      { target: { value: content } } as SelectChangeEvent,
+                      "content"
+                    );
+                    setIsEditing(false);
+                  }}
+                >
+                  <SaveIcon />
+                </IconButton>
+              </div>
+              <AceEditor
+                mode="javascript"
+                theme="github"
+                value={content}
+                onChange={(value) => {
+                  setContent(value);
                 }}
-              >
-                <SaveIcon />
-              </IconButton>
+                name="script-editor"
+                readOnly={!isEditing}
+                editorProps={{ $blockScrolling: true }}
+                setOptions={{
+                  enableBasicAutocompletion: true,
+                  enableLiveAutocompletion: true,
+                  enableSnippets: true,
+                }}
+                style={{ opacity: isEditing ? 1 : 0.5 }}
+              />
             </div>
-            <AceEditor
-              mode="javascript"
-              theme="github"
-              value={content}
-              onChange={(value) => {
-                setContent(value);
-              }}
-              name="script-editor"
-              readOnly={!isEditing}
-              editorProps={{ $blockScrolling: true }}
-              setOptions={{
-                enableBasicAutocompletion: true,
-                enableLiveAutocompletion: true,
-                enableSnippets: true,
-              }}
-              style={{ opacity: isEditing ? 1 : 0.5 }}
-            />
           </div>
         </Card.Body>
       </Card>


### PR DESCRIPTION
## Script Execution Popup and Description
This pull request regards issues #103 and #183, by completing the following:
- Added a field in the scripting tab in the settings page to make descriptions editable
- Added the descriptions as tooltips upon hover on the script's list view button
- Added the possibility of having multiple scripts on one table
- Added a popup to confirm script loading/execution for the user

| Description Field |
| --------- | 
|![image](https://github.com/WillTrem/UInnovate/assets/78221579/a8a0d2ec-9686-4ed2-9a60-96410b89a5f8)|

| Tooltips |
| -------- |
|![image](https://github.com/WillTrem/UInnovate/assets/78221579/caf5d9be-7912-4168-b895-2788cfb898ad)|

| Script Execution Popup |
| ---------- |
|![image](https://github.com/WillTrem/UInnovate/assets/78221579/69bbc947-eecd-42d7-ba90-c2a2f7f3690b)|