### PR TITLE
Fixing bug with changing the settings to use the config instead of local storage. 

### DIFF
--- a/UInnovateApp/src/components/SlidingComponents/LookUpTableDetails.tsx
+++ b/UInnovateApp/src/components/SlidingComponents/LookUpTableDetails.tsx
@@ -9,16 +9,11 @@ interface TableListViewProps {
 }
 
 const LookUpTableDetails: React.FC<TableListViewProps> = ({ table }: TableListViewProps) => {
-  const name = table.table_name + "T";
-  const Local = localStorage.getItem(name);
-  if (Local == null) {
-    return (<></>)
-  }
-  else {
+
     const [Columns, setColumns] = useState<Column[][]>([]);
     const [rows, setRows] = useState<Row[][] | undefined>([]);
-    const getTable = JSON.parse(Local!);
-    var count = Object.keys(getTable).length - 1;
+    const getTable = JSON.parse(table.lookup_tables);
+    const count = Object.keys(getTable).length - 1;
 
 
     const LookUpTables = (num: number) => {
@@ -140,7 +135,7 @@ const LookUpTableDetails: React.FC<TableListViewProps> = ({ table }: TableListVi
 
 
 
-  }
+  
 }
 
 export default LookUpTableDetails;

--- a/UInnovateApp/src/components/SlidingComponents/LookUpTableDetails.tsx
+++ b/UInnovateApp/src/components/SlidingComponents/LookUpTableDetails.tsx
@@ -27,9 +27,11 @@ const LookUpTableDetails: React.FC<TableListViewProps> = ({ table }: TableListVi
         const search = table.getColumns()
 
         let toolsColumn: string = "";
+        let toolsColumnName: string = "";
         search?.map((attribute) => {
           if (attribute.references_table == tableName) {
             toolsColumn = attribute.column_name;
+            toolsColumnName = attribute.references_by;
           }
           else {
             return (<>no</>);
@@ -58,7 +60,7 @@ const LookUpTableDetails: React.FC<TableListViewProps> = ({ table }: TableListVi
             const data_accessor: DataAccessor = vmd.getRowsDataAccessorForLookUpTable(
               schemaObj.schema_name,
               tableName,
-              toolsColumn,
+              toolsColumnName,
               connectionID
             );
             console.log(data_accessor);
@@ -84,7 +86,7 @@ const LookUpTableDetails: React.FC<TableListViewProps> = ({ table }: TableListVi
        
         return (
           <div>
-            {tableName} look up table:
+            {tableName} look up table: 
             <div>
               {/* Here is the table name: {toolsColumn} */}
             </div>

--- a/UInnovateApp/src/components/SlidingComponents/LookUpTableDetails.tsx
+++ b/UInnovateApp/src/components/SlidingComponents/LookUpTableDetails.tsx
@@ -32,13 +32,13 @@ const LookUpTableDetails: React.FC<TableListViewProps> = ({ table }: TableListVi
             toolsColumn = attribute.column_name;
           }
           else {
-            return (<>nothing</>);
+            return (<>no</>);
           }
         });
-        const temp = toolsColumn + "L";
+        const temp = toolsColumn;
         const connectionID = localStorage.getItem(temp);
         if (connectionID == undefined) {
-          return (<>nothing</>);
+          return (<>Missing ConnectionID</>);
         }
 
 

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -88,12 +88,6 @@ const TableListView: React.FC<TableListViewProps> = ({
   const [PageNumber, setPageNumber] = useState<number>(1);
   const [Plength, setLength] = useState<number>(0);
   const [showTable, setShowTable] = useState<boolean>(false);
-  const name = table.table_name + "T";
-  const Local = localStorage.getItem(name);
-  if (Local == null) {
-    const nulll = Local;
-  }
-  const getTable = JSON.parse(Local!);
 
   const getRows = async () => {
     const attributes = table.getVisibleColumns();
@@ -318,7 +312,7 @@ const TableListView: React.FC<TableListViewProps> = ({
       }
 
       if (column.references_table != null) {
-        const string = column.column_name + "L";
+        const string = column.column_name;
         localStorage.setItem(
           string,
           currentRow.row[column.column_name] as string

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -707,10 +707,10 @@ const TableListView: React.FC<TableListViewProps> = ({
           </div>
         </div>
         <div style={{ paddingBottom: "2em" }}>
-          {localStorage.getItem(table.table_name + "T") === null ||
-          getTable[-1] == "none" ? (
+          {table.lookup_tables=="null" ? (
             <div></div>
-          ) : showTable ? (
+          ) : JSON.parse(table.lookup_tables)[-1] =="none" ? (
+          <div></div>) : showTable ? (
             <div style={{ paddingBottom: "2em" }}>
               <LookUpTableDetails table={table} />
             </div>
@@ -721,7 +721,7 @@ const TableListView: React.FC<TableListViewProps> = ({
               style={{ marginLeft: 15 }}
               onClick={() => setShowTable(true)}
             >
-              Show Look up Table
+              Show Look Up Table
             </Button>
           )}
         </div>

--- a/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
+++ b/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
@@ -8,6 +8,8 @@ import "../../styles/TableItem.css";
 import { Table } from "../../virtualmodel/VMD";
 import buttonStyle from '../TableEnumView'
 import { Row } from '../../virtualmodel/DataAccessor';
+import { ConfigProperty } from '../../virtualmodel/ConfigProperties';
+import { ConfigValueType, useConfig } from '../../contexts/ConfigContext';
 
 
 type LookUpTableProps = {
@@ -19,8 +21,16 @@ type DefaultRow = {
 
 const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) => {
 
+  const { updateConfig } = useConfig();
 
-
+  const updateTableConfig = (property: ConfigProperty, value: string) => {
+    const newConfigValue: ConfigValueType = {
+      property,
+      table: table.table_name,
+      value,
+    };
+    updateConfig(newConfigValue);
+  };
 
   const attributes = table.getColumns();
   let count = 0;
@@ -36,7 +46,21 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
     }
   });
   if (count == 0) {
-    return (<></>)
+    const handlechecktest: React.MouseEventHandler<HTMLButtonElement> | undefined = async () => {
+      console.log(table.lookup_tables)
+      table.setLookupTables("check1");
+      await updateTableConfig(ConfigProperty.LOOKUP_TABLES, ("check1").toString());
+
+      console.log(table.lookup_tables)
+      
+    } 
+
+    return (<div>
+    <button onClick={handlechecktest}>
+
+    </button>
+    {table.lookup_tables}
+    </div>)
   }
   else {
 
@@ -113,11 +137,12 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
     
 
 
-    const HandleChange = (index: number) => (event: React.ChangeEvent<{ value: unknown }>) => {
+    const HandleChange =  (index: number) => (event: React.ChangeEvent<{ value: unknown }>) => {
       setSelectInput((prevSelectInput) => ({
         ...prevSelectInput,
         [index]: event.target.value,
       }));
+      
 
 
     };

--- a/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
+++ b/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
@@ -79,7 +79,7 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
   
     const MyButtonComponent = ({ buttonIndex }: { buttonIndex: number }) => {
       return (
-        <div >
+        <div style={{marginTop:'2em'}} >
 
           <FormControl size="small">
             <h6>Lookup Tables</h6>
@@ -202,7 +202,7 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
             -
           </button>
         </div>
-        <div style={{ display: 'flex', flexDirection: 'column', marginLeft: '100px', width: '273.08', marginTop: '2em' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', marginLeft: '100px', width: '273.08'}}>
           {[...Array(counter)].map((_, index) => (
 
             <MyButtonComponent key={index} buttonIndex={index} />

--- a/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
+++ b/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
@@ -31,7 +31,9 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
     };
     updateConfig(newConfigValue);
   };
-
+ 
+  
+  
   const attributes = table.getColumns();
   let count = 0;
   const referencesTableList: string[] = [];
@@ -46,50 +48,50 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
     }
   });
   if (count == 0) {
-    const handlechecktest: React.MouseEventHandler<HTMLButtonElement> | undefined = async () => {
-      console.log(table.lookup_tables)
-      table.setLookupTables("check1");
-      await updateTableConfig(ConfigProperty.LOOKUP_TABLES, ("check1").toString());
-
-      console.log(table.lookup_tables)
-      
-    } 
+   
 
     return (<div>
-    <button onClick={handlechecktest}>
-
-    </button>
-    {table.lookup_tables}
+  
     </div>)
   }
   else {
 
-    let defaultRow = new Row({});
+    const defaultRow = new Row({});
     for (let i = -1; i < count - 1; i++) {
 
       defaultRow[i] = 'none';
     }
 
 
-    const name = table.table_name + "T";
     const [SelectInput, setSelectInput] = useState<Row>(() => {
-      const savedLookUp = localStorage.getItem(name);
-      if (savedLookUp && savedLookUp !== '{}' && savedLookUp !== '""') {
-
-        return JSON.parse(savedLookUp);
-      } else {
+      if(table.lookup_tables=="null"){
         return (defaultRow);
       }
-    })
+      else {
+         const obj = JSON.parse(table.lookup_tables);
+        return (obj);
+      }
+        
+      }
+    )
 
+    // const [SelectInput, setSelectInput] = useState<Row>(() => {
+    //   const savedLookUp = localStorage.getItem(name);
+    //   if (savedLookUp && savedLookUp !== '{}' && savedLookUp !== '""') {
 
-    Storage.prototype.setObj = function (key: string, obj: string) {
-      return this.setItem(key, JSON.stringify(obj))
-    }
-    Storage.prototype.getObj = function (key: string) {
-      const item = this.getItem(key);
-      return item ? JSON.parse(item) : null;
-    }
+    //     return JSON.parse(savedLookUp);
+    //   } else {
+    //     return (defaultRow);
+    //   }
+    // })
+
+    // Storage.prototype.setObj = function (key: string, obj: string) {
+    //   return this.setItem(key, JSON.stringify(obj))
+    // }
+    // Storage.prototype.getObj = function (key: string) {
+    //   const item = this.getItem(key);
+    //   return item ? JSON.parse(item) : null;
+    // }
 
   
     const MyButtonComponent = ({ buttonIndex }: { buttonIndex: number }) => {
@@ -131,10 +133,17 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
     }, [counter]);
 
     useEffect(() => {
-      localStorage.setItem(name, JSON.stringify(SelectInput));
+      
+      setSelectInputConfig();
     }, [SelectInput]);
 
-    
+    const setSelectInputConfig = async () => {
+      const objstring = JSON.stringify(SelectInput);
+      table.setLookupTables(objstring);
+      await updateTableConfig(ConfigProperty.LOOKUP_TABLES, objstring);
+
+    };
+  
 
 
     const HandleChange =  (index: number) => (event: React.ChangeEvent<{ value: unknown }>) => {
@@ -213,6 +222,8 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
 
           ))}
         </div>
+        {table.lookup_tables} 
+        {JSON.stringify(defaultRow)}
       </div>
     );
   }

--- a/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
+++ b/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
@@ -92,7 +92,7 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
               ))}
             </Select>
             <FormHelperText>
-              To customize the default layout of the table
+            To customize the table which will be looked up 
             </FormHelperText>
           </FormControl>
         </div>
@@ -185,7 +185,7 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
               ))}
             </Select>
             <FormHelperText>
-              To customize the default layout of the table
+              To customize the table which will be looked up
             </FormHelperText>
           </FormControl>
 

--- a/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
+++ b/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
@@ -75,23 +75,6 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
       }
     )
 
-    // const [SelectInput, setSelectInput] = useState<Row>(() => {
-    //   const savedLookUp = localStorage.getItem(name);
-    //   if (savedLookUp && savedLookUp !== '{}' && savedLookUp !== '""') {
-
-    //     return JSON.parse(savedLookUp);
-    //   } else {
-    //     return (defaultRow);
-    //   }
-    // })
-
-    // Storage.prototype.setObj = function (key: string, obj: string) {
-    //   return this.setItem(key, JSON.stringify(obj))
-    // }
-    // Storage.prototype.getObj = function (key: string) {
-    //   const item = this.getItem(key);
-    //   return item ? JSON.parse(item) : null;
-    // }
 
   
     const MyButtonComponent = ({ buttonIndex }: { buttonIndex: number }) => {
@@ -118,19 +101,22 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
 
 
     const [counter, setCounter] = useState(() => {
-      // Retrieve the counter value from local storage when initializing state
-      const savedCounter = localStorage.getItem(table.table_name);
-      return savedCounter !== null ? Number(savedCounter) : 0;
+      return parseInt(table.lookup_counter, 10);
     });
 
 
 
     useEffect(() => {
-      // Store the counter value in local storage whenever it changes
-      localStorage.setItem(table.table_name, counter.toString());
-      if (counter > 0 && Object.keys(SelectInput).length == 1) {
-      }
+      setCounterConfig();
+     
     }, [counter]);
+    const setCounterConfig = async () => {
+      table.setLookupCounter(counter.toString())
+      await updateTableConfig(ConfigProperty.LOOKUP_COUNTER, counter.toString());
+
+    };
+  
+
 
     useEffect(() => {
       
@@ -157,12 +143,13 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
     };
 
 
-    const handleButtonClick = () => {
+    const handleButtonClick = async () => {
       if (count - 1 == counter || count == 0) {
         alert("You can't add more lookup tables")
       }
-      else
+      else{
         setCounter((Counter) => Counter + 1);
+      }
     };
 
     const handleButtonClickDelete = () => {
@@ -222,8 +209,6 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
 
           ))}
         </div>
-        {table.lookup_tables} 
-        {JSON.stringify(defaultRow)}
       </div>
     );
   }

--- a/UInnovateApp/src/virtualmodel/ConfigProperties.ts
+++ b/UInnovateApp/src/virtualmodel/ConfigProperties.ts
@@ -7,5 +7,6 @@ export enum ConfigProperty {
   COLUMN_DISPLAY_TYPE = "column_display_type",
   METADATA_VIEW = "metadata_view",
   DETAILS_VIEW = "details_view",
-  STAND_ALONE_DETAILS_VIEW = "stand_alone_details_view"
+  STAND_ALONE_DETAILS_VIEW = "stand_alone_details_view",
+  LOOKUP_TABLES="lookup_tables"
 }

--- a/UInnovateApp/src/virtualmodel/ConfigProperties.ts
+++ b/UInnovateApp/src/virtualmodel/ConfigProperties.ts
@@ -8,5 +8,6 @@ export enum ConfigProperty {
   METADATA_VIEW = "metadata_view",
   DETAILS_VIEW = "details_view",
   STAND_ALONE_DETAILS_VIEW = "stand_alone_details_view",
-  LOOKUP_TABLES="lookup_tables"
+  LOOKUP_TABLES="lookup_tables",
+  LOOKUP_COUNTER="lookup_counter"
 }

--- a/UInnovateApp/src/virtualmodel/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/VMD.tsx
@@ -278,6 +278,9 @@ class VirtualModelDefinition {
           case "lookup_tables":
             table.lookup_tables = config.value as string;
             break;
+          case "lookup_counter":
+            table.lookup_counter = config.value as string;
+            break;
         }
       });
       this.config_data_fetched = true;
@@ -511,6 +514,7 @@ export class Table {
   url: string;
   lookup_tables: string;
   stand_alone_details_view: boolean;
+  lookup_counter: string;
 
   constructor(table_name: string) {
     this.table_name = table_name;
@@ -521,6 +525,7 @@ export class Table {
     this.url = API_BASE_URL + table_name;
     this.lookup_tables = "null";
     this.stand_alone_details_view = false;
+    this.lookup_counter = "0";
   }
 
   // Method to add a new column to the table object
@@ -638,6 +643,19 @@ export class Table {
   setStandAloneDetailsView(stand_alone_details_view: boolean) {
     this.stand_alone_details_view = stand_alone_details_view;
   }
+
+  // Method to get the table's lookup counter
+  // return type : number
+  getLookupCounter() {
+    return this.lookup_counter;
+  }
+
+  // Method to set the table's lookup counter
+  // return type : void
+  setLookupCounter(lookup_counter: string) {
+    this.lookup_counter = lookup_counter;
+  }
+
 }
 
 export class Column {

--- a/UInnovateApp/src/virtualmodel/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/VMD.tsx
@@ -275,6 +275,9 @@ class VirtualModelDefinition {
           case "stand_alone_details_view":
             table.stand_alone_details_view = config.value === "true";
             break;
+          case "lookup_tables":
+            table.lookup_tables = config.value as string;
+            break;
         }
       });
       this.config_data_fetched = true;
@@ -506,7 +509,7 @@ export class Table {
   has_details_view: boolean;
   columns: Column[];
   url: string;
-  lookup_tables: Row;
+  lookup_tables: string;
   stand_alone_details_view: boolean;
 
   constructor(table_name: string) {
@@ -516,7 +519,7 @@ export class Table {
     this.has_details_view = true;
     this.columns = [];
     this.url = API_BASE_URL + table_name;
-    this.lookup_tables = { "-1": "none" };
+    this.lookup_tables = "null";
     this.stand_alone_details_view = false;
   }
 
@@ -620,7 +623,7 @@ export class Table {
 
   // Method to set the table's lookup tables
   // return type : void
-  setLookupTables(lookup_tables: Row) {
+  setLookupTables(lookup_tables: string) {
     this.lookup_tables = lookup_tables;
   }
 

--- a/UInnovateApp/src/virtualmodel/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/VMD.tsx
@@ -177,7 +177,8 @@ class VirtualModelDefinition {
         table.addColumn(
           new Column(data.column),
           data.references_table,
-          data.is_editable
+          data.is_editable,
+          data.references_by
         );
       });
 
@@ -529,9 +530,10 @@ export class Table {
   }
 
   // Method to add a new column to the table object
-  addColumn(column: Column, references_table: string, is_editable: boolean) {
+  addColumn(column: Column, references_table: string, is_editable: boolean, references_by: string) {
     column.setReferenceTable(references_table);
     column.setEditability(is_editable);
+    column.setReferencesBy(references_by);
 
     this.columns.push(column);
   }
@@ -665,6 +667,7 @@ export class Column {
   reqOnCreate: boolean;
   references_table: string;
   is_editable: boolean;
+  references_by: string;
 
   constructor(column_name: string) {
     this.column_name = column_name;
@@ -673,6 +676,7 @@ export class Column {
     this.reqOnCreate = false;
     this.references_table = "";
     this.is_editable = false;
+    this.references_by = "";
   }
 
   // Method to set the column type
@@ -710,6 +714,18 @@ export class Column {
   getEditability() {
     return this.is_editable;
   }
+
+  // Method to set the column's references by
+  // return type : void
+  setReferencesBy(references_by: string) {
+    this.references_by = references_by;
+  }
+
+  // Method to get the column's references by
+  // return type : string
+  getReferencesBy() {
+    return this.references_by;
+  }
 }
 
 export class View {
@@ -734,6 +750,7 @@ interface ColumnData {
   column: string;
   references_table: string;
   is_editable: boolean;
+  references_by: string;
 }
 // Defining ViewData interface for type checking when calling /views with the API
 interface ViewData {

--- a/database/meta.sql
+++ b/database/meta.sql
@@ -35,54 +35,55 @@ CREATE OR REPLACE VIEW meta.constraints ("schema_name", "table_name", "column_na
 -- Creating the columns view
 CREATE OR REPLACE VIEW meta.columns ("schema", "table", "column", "references_table", "references_by", "is_editable") AS 
 (
-    SELECT DISTINCT ON (c.table_schema, c.table_name, c.column_name)
-        c.table_schema, 
-        c.table_name, 
-        c.column_name,  
-        rc.referenced_table,
-        rc.referee_column AS references_by, -- Modified this line
-        CASE WHEN c.column_name = pk.table_pkey THEN false ELSE true END AS is_editable
-    FROM information_schema.columns AS c
-    LEFT JOIN 
-    (
-        SELECT DISTINCT ON (cl.relname, att.attname, cl2.relname)
-            cl.relname as referee_table,  
-            att.attname as referee_column, 
-            cl2.relname as referenced_table, 
-            att2.attname as referenced_column 
-        FROM pg_catalog.pg_constraint as co
-        LEFT JOIN pg_catalog.pg_class as cl
-        ON co.conrelid = cl.oid
-        LEFT JOIN pg_catalog.pg_class as cl2
-        ON co.confrelid = cl2.oid
-        LEFT JOIN pg_catalog.pg_attribute as att
-        ON cl.oid = att.attrelid AND ARRAY[att.attnum] = co.conkey
-        LEFT JOIN pg_catalog.pg_attribute as att2
-        ON cl2.oid = att2.attrelid AND ARRAY[att2.attnum] = co.confkey
-        WHERE contype = 'f'
-    ) AS rc
-    ON c.table_name = rc.referenced_table AND c.column_name = rc.referenced_column
-    -- New LEFT JOIN for primary key references
-    LEFT JOIN 
-    (
-        SELECT 
-            cl.relname as table_name,  
-            att.attname as table_pkey
-        FROM pg_catalog.pg_constraint as co
-        LEFT JOIN pg_catalog.pg_class as cl
-        ON co.conrelid = cl.oid
-        LEFT JOIN pg_catalog.pg_attribute as att
-        ON cl.oid = att.attrelid AND ARRAY[att.attnum] = co.conkey
-        WHERE contype = 'p'
-    ) AS pk
-    ON c.table_name = pk.table_name
-    
-    WHERE c.table_name IN 
-    (
-        SELECT "table" FROM meta.tables
-    )
-    ORDER BY c.table_schema, c.table_name, c.column_name
+   SELECT DISTINCT ON (c.table_schema, c.table_name, c.column_name)
+    c.table_schema, 
+    c.table_name, 
+    c.column_name,  
+    rc.referenced_table,
+    rc.referenced_column AS references_by, -- Added this line
+    CASE WHEN c.column_name = pk.table_pkey THEN false ELSE true END AS is_editable
+FROM information_schema.columns AS c
+LEFT JOIN 
+(
+    SELECT DISTINCT ON (cl.relname, att.attname)
+        cl.relname as referee_table,  
+        att.attname as referee_column, 
+        cl2.relname as referenced_table, 
+        att2.attname as referenced_column 
+    FROM pg_catalog.pg_constraint as co
+    LEFT JOIN pg_catalog.pg_class as cl
+    ON co.conrelid = cl.oid
+    LEFT JOIN pg_catalog.pg_class as cl2
+    ON co.confrelid = cl2.oid
+    LEFT JOIN pg_catalog.pg_attribute as att
+    ON cl.oid = att.attrelid AND ARRAY[att.attnum] = co.conkey
+    LEFT JOIN pg_catalog.pg_attribute as att2
+    ON cl2.oid = att2.attrelid AND ARRAY[att2.attnum] = co.confkey
+    WHERE contype = 'f'
+) AS rc
+ON c.column_name = rc.referee_column AND c.table_name != rc.referenced_table
+-- New LEFT JOIN for primary key references
+LEFT JOIN 
+(
+    SELECT 
+        cl.relname as table_name,  
+        att.attname as table_pkey
+    FROM pg_catalog.pg_constraint as co
+    LEFT JOIN pg_catalog.pg_class as cl
+    ON co.conrelid = cl.oid
+    LEFT JOIN pg_catalog.pg_attribute as att
+    ON cl.oid = att.attrelid AND ARRAY[att.attnum] = co.conkey
+    WHERE contype = 'p'
+) AS pk
+ON c.table_name = pk.table_name
+
+WHERE c.table_name IN 
+(
+    SELECT "table" FROM meta.tables
+)
+ORDER BY c.table_schema, c.table_name, c.column_name
 );
+
 
 
 

--- a/database/meta_data.sql
+++ b/database/meta_data.sql
@@ -8,7 +8,8 @@ VALUES
     ('column_display_type', 'How to display a column', 'string', 'text'),
     ('metadata_view', 'Default view when showing the metadata information of a table/column', 'boolean', 'false' ),
     ('details_view', 'Visibility state of the details view for a table', 'boolean', 'true'),
-    ('stand_alone_details_view', 'Visibility state of the stand alone details view for a table', 'boolean', 'false');
+    ('stand_alone_details_view', 'Visibility state of the stand alone details view for a table', 'boolean', 'false'),
+    ('lookup_tables', 'List of tables that are used as lookup tables', 'string', 'null');
     -- ADD ANY NEW CONFIG PROPERTIES HERE
 
 -- Insert the default column display typess for each  app_service_support column
@@ -16,7 +17,7 @@ INSERT INTO meta.appconfig_values (property, value, "table", "column")
 SELECT
     CFP.name, default_value, C.table, C.column
 FROM meta.columns as C, meta.appconfig_properties as CFP
-WHERE schema = ' app_service_support' AND (CFP.name != 'table_view' AND CFP.name != 'details_view' AND CFP.name != 'stand_alone_details_view');
+WHERE schema = ' app_service_support' AND (CFP.name != 'table_view' AND CFP.name != 'details_view' AND CFP.name != 'stand_alone_details_view' AND CFP.name != 'lookup_tables');
 
 
 -- Insert the default column display typess for each  app_service_support table

--- a/database/meta_data.sql
+++ b/database/meta_data.sql
@@ -9,7 +9,8 @@ VALUES
     ('metadata_view', 'Default view when showing the metadata information of a table/column', 'boolean', 'false' ),
     ('details_view', 'Visibility state of the details view for a table', 'boolean', 'true'),
     ('stand_alone_details_view', 'Visibility state of the stand alone details view for a table', 'boolean', 'false'),
-    ('lookup_tables', 'List of tables that are used as lookup tables', 'string', 'null');
+    ('lookup_tables', 'List of tables that are used as lookup tables', 'string', 'null'),
+    ('lookup_counter', 'Counter for the amount of tables displayed for lookup tables', 'string', '0');
     -- ADD ANY NEW CONFIG PROPERTIES HERE
 
 -- Insert the default column display typess for each  app_service_support column
@@ -17,7 +18,7 @@ INSERT INTO meta.appconfig_values (property, value, "table", "column")
 SELECT
     CFP.name, default_value, C.table, C.column
 FROM meta.columns as C, meta.appconfig_properties as CFP
-WHERE schema = ' app_service_support' AND (CFP.name != 'table_view' AND CFP.name != 'details_view' AND CFP.name != 'stand_alone_details_view' AND CFP.name != 'lookup_tables');
+WHERE schema = ' app_service_support' AND (CFP.name != 'table_view' AND CFP.name != 'details_view' AND CFP.name != 'stand_alone_details_view' AND CFP.name != 'lookup_tables' AND CFP.name != 'lookup_counter');
 
 
 -- Insert the default column display typess for each  app_service_support table
@@ -26,7 +27,7 @@ SELECT
     CFP.name, default_value, T.table
 FROM meta.tables as T, meta.appconfig_properties as CFP
 WHERE schema = ' app_service_support' AND CFP.name = 'table_view'
-OR CFP.name = 'visible' OR CFP.name = 'metadata_view' OR CFP.name = 'details_view' OR CFP.name = 'stand_alone_details_view';
+OR CFP.name = 'visible' OR CFP.name = 'metadata_view' OR CFP.name = 'details_view' OR CFP.name = 'stand_alone_details_view' OR CFP.name = 'lookup_tables' OR CFP.name = 'lookup_counter';
 
 -- Insert a default script for the scripts table
 INSERT INTO meta.scripts (name, description, content, table_name)


### PR DESCRIPTION
related to #169 
Don't forget to refresh_database.sh to get the new features, as well you may clear your local storage when in the settings.

Other bugs were fixed that weren't mentioned in issues, this includes bugs with the referencing of tables that shared the same value but had a different column name, causing the API GET call to fail. 

Now the settings for lookup tables do not use local storage and instead rely on the config.