### PR TITLE
Adding new labels that should be editable and distinguish them via icons

### DIFF
--- a/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
@@ -6,6 +6,9 @@ import { Modal, Form } from "react-bootstrap";
 import { Button } from "@mui/material";
 import TableComponent from "react-bootstrap/Table";
 import { IoLockClosed } from "react-icons/io5";
+import { IoMdAddCircle } from "react-icons/io";
+import { PiNotePencilBold } from "react-icons/pi";
+import { MdDelete } from "react-icons/md";
 
 
 const buttonStyle = {
@@ -24,19 +27,29 @@ const InternationalizationTab = () => {
     const [newLanguageName, setNewLanguageName] = useState('');
 
     const [languages, setLanguages] = useState<string[]>([]);
-
 	
     const getTranslations = async () => {
-        const data_accessor: DataAccessor = vmd.getViewRowsDataAccessor(
-            "meta",
-            "i18n_translations" 
-        );
+        try {
+            const data_accessor: DataAccessor = vmd.getViewRowsDataAccessor(
+                "meta",
+                "i18n_translations"
+            );
     
-        const rows = await data_accessor.fetchRows();
-        if (rows) {
-            setTranslations(rows);
+            const rows = await data_accessor.fetchRows();
+            if (rows) {
+                console.log("Fetched rows:", rows);
+    
+                const translationsWithIsDefault = rows.map(row => ({
+                    ...row,
+                    is_default: row.is_default || false,
+                }));
+    
+                setTranslations(translationsWithIsDefault);
+            }
+        } catch (error) {
+            console.error('Error fetching translations:', error);
         }
-    }
+    };
 
 	useEffect(() => {
 		getTranslations();
@@ -95,6 +108,41 @@ const InternationalizationTab = () => {
         setShowModal(false);
     };
 
+    const handleAddRowClick = async () => {
+        try {
+            // Prompt the user for a label name
+            const labelName = window.prompt('Enter a label name:');
+    
+            if (labelName !== null) { 
+                // Add a new row to i18n_keys with is_default set to false and the provided label name
+                await vmd.getAddRowDataAccessor(
+                    "meta",
+                    "i18n_keys",
+                    {
+                        key_code: labelName.trim() || "New Label",
+                        is_default: false, // Set is_default to false for user-added labels
+                    }
+                ).addRow();
+    
+                // Fetch the updated translations
+                await getTranslations();
+    
+                console.log("Adding a new label...");
+            }
+        } catch (error) {
+            console.error('Error adding a new label:', error);
+        }
+    };
+
+    // TODO: Implement edit functionality to save directly to the database and reflect the changes in the UI
+    const handleEdit = async (keyCode: string, editedValue: string) => {
+        try {    
+            console.log(`Editing label with keyCode ${keyCode} to value ${editedValue}`);
+        } catch (error) {
+            console.error("Error editing label:", error);
+        }
+    };
+    
 
     return (
     <div>
@@ -178,16 +226,32 @@ const InternationalizationTab = () => {
                                 if (translation) {
                                     return (
                                         <TranslationTableRow
-                                            key={idx}
-                                            keyCode={translation["key_code"] as string}
-                                            value={translation["value"] as string}
-                                        />
+                                        key={idx}
+                                        keyCode={translation["key_code"] as string}
+                                        value={translation["value"] as string}
+                                        is_default={translation["is_default"] as boolean}
+                                        onEdit={handleEdit}
+                                    />
                                         );
                                     }
                                     return <React.Fragment key={idx} />;
                             })}
                         </tbody>
                     </TableComponent>
+                    <div>
+                        <div
+                            className="container"
+                            style={{ display: "flex", justifyContent: "center" }}
+                        >
+                            <Button
+                            variant="contained"
+                            style={buttonStyle}
+                            onClick={() => handleAddRowClick()}
+                            >
+                                <IoMdAddCircle className="button-icon" />
+                            </Button>
+                        </div>
+                </div>
                 </Tab.Content>
             </Line>
         </Tab.Container>
@@ -197,13 +261,106 @@ const InternationalizationTab = () => {
 
 interface TranslationTableRowProps {
 	keyCode?: string,
-	value?: string
+	value?: string,
+    is_default?: boolean,
+    onEdit: (keyCode: string, newValue: string) => void;
 }
 
-const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ keyCode, value }) => {
-	return <tr>
-		<td>{keyCode} <IoLockClosed /></td>
-		<td>{value}</td>
-	</tr >
-}
+const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ keyCode, value, is_default, onEdit }) => {
+    const [isEditing, setIsEditing] = useState(false);
+    const [editedValue, setEditedValue] = useState(value || "");
+
+    const handleDoubleClick = () => {
+        if (!is_default) {
+            setIsEditing(true);
+        }
+    };
+
+    const handleBlur = () => {
+        if (!is_default) {
+            setIsEditing(false);
+            saveChanges(); 
+        }
+    };
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setEditedValue(e.target.value);
+        // Automatically save changes when the input field is changed
+        saveChanges();
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            setIsEditing(false);
+            saveChanges(); // Save changes on Enter key press
+        }
+    };
+
+    const handleClickOutside = (e: MouseEvent) => {
+        const target = e.target as HTMLElement;
+        if (target.tagName !== "INPUT") {
+            setIsEditing(false);
+            saveChanges(); // Save changes when clicking outside the input field
+        }
+    };
+
+    // TODO: Implement delete functionality
+    const handleDelete = async (keyCode: string) => {
+        try {
+            console.log(`Deleted label with keyCode ${keyCode}`);
+        } catch (error) {
+            console.error('Error deleting label:', error);
+        }
+    };
+    
+
+    // TODO: Implement save changes functionality
+    const saveChanges = async () => {
+        try {
+            if (value !== editedValue) {
+                onEdit(keyCode || "", editedValue);
+            }
+        } catch (error) {
+            console.error('Error saving changes:', error);
+        }
+    };
+
+    useEffect(() => {
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, []); 
+
+    return (
+        <tr>
+            <td onDoubleClick={handleDoubleClick}>
+            <input
+                value={isEditing ? editedValue : keyCode}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                onKeyDown={handleKeyDown}
+                readOnly={!isEditing}
+                style={{
+                    border: 'none',
+                    outline: 'none',
+                    backgroundColor: isEditing ? '#f2f2f2' : 'transparent', 
+                    borderRadius: '4px',  
+                }}
+            />
+                {is_default ? <IoLockClosed /> : (
+                    <>
+                        <PiNotePencilBold
+                            style={{ marginLeft: 5, cursor: 'pointer' }}
+                            onClick={handleDoubleClick}
+                        /> {/* Edit icon */}
+                        <MdDelete onClick={handleDelete} style={{ marginLeft: 5, cursor: 'pointer' }} /> {/* Delete icon */}
+                    </>
+                )}
+            </td>
+        </tr>
+    );
+};
+
 export default InternationalizationTab;

--- a/database/meta.sql
+++ b/database/meta.sql
@@ -155,9 +155,9 @@ CREATE TABLE IF NOT EXISTS meta.i18n_languages (
 -- Creating the keys table
 CREATE TABLE IF NOT EXISTS meta.i18n_keys (
     id SERIAL PRIMARY KEY,
-    key_code VARCHAR(255) UNIQUE NOT NULL
+    key_code VARCHAR(255) UNIQUE NOT NULL,
+    is_default BOOLEAN DEFAULT false  -- Add the is_default column here
 );
-
 -- Creating the values table
 CREATE TABLE IF NOT EXISTS meta.i18n_values (
     id SERIAL PRIMARY KEY,
@@ -167,13 +167,14 @@ CREATE TABLE IF NOT EXISTS meta.i18n_values (
     CONSTRAINT unique_translation UNIQUE (language_id, key_id)
 );
 
--- Creating the translation view (combines the languages, keys and values tables)
+-- Creating the translation view (combines the languages, keys, and values tables)
 CREATE OR REPLACE VIEW meta.i18n_translations AS
 SELECT
     k.id AS translation_id,
     l.language_code,
     k.key_code,
-    COALESCE(v.value, '') AS value
+    COALESCE(v.value, '') AS value,
+    k.is_default  -- Adding the is_default attribute
 FROM
     meta.i18n_languages l
 CROSS JOIN
@@ -185,7 +186,8 @@ SELECT
     k.id AS translation_id,
     NULL AS language_code,
     k.key_code,
-    '' AS value
+    '' AS value,
+    k.is_default  -- Adding the is_default attribute
 FROM
     meta.i18n_keys k
 WHERE

--- a/database/meta_data.sql
+++ b/database/meta_data.sql
@@ -34,10 +34,6 @@ INSERT INTO meta.scripts (name, description, content, table_name)
 VALUES
     ('default_script', 'Simple script to print something on the console.', 'console.log("Hello World");', 'scripts');
 
--- Inser the new column to visually flag the default values
-ALTER TABLE meta.i18n_keys
-ADD COLUMN is_default BOOLEAN DEFAULT false;
-
 -- Insert the tables names, columns names, schema tables into the i18n_keys table
 -- Insert unique column names into i18n_keys
 INSERT INTO meta.i18n_keys (key_code, is_default)


### PR DESCRIPTION
This PR is containing only the functional part of the US #179, hence the US is still incomplete and will have to be pushed back to the next iteration.

Recap: 

1. The user is able to add new labels via the window prompt, and it should be reflected onto the database and the UI.
<img width="1340" alt="Screenshot 2024-01-26 at 11 00 29 PM" src="https://github.com/WillTrem/UInnovate/assets/74876532/aa8bcd4f-c82d-4af6-96a9-1119f81c1af5">
<img width="1246" alt="Screenshot 2024-01-26 at 11 01 11 PM" src="https://github.com/WillTrem/UInnovate/assets/74876532/76b62af0-c4d6-4173-848d-3bd1995c7cd9">
<img width="524" alt="Screenshot 2024-01-26 at 11 02 13 PM" src="https://github.com/WillTrem/UInnovate/assets/74876532/c1e2718f-4fc4-49af-b28a-1924ec25f34a">


2. The user will noticed that the labels can be distinguished more easily, hence if it contains the lock icon it cannot be edited but if it contains the editable labels it will have a pencil icon and a delete icon.
<img width="244" alt="Screenshot 2024-01-26 at 11 02 42 PM" src="https://github.com/WillTrem/UInnovate/assets/74876532/c54aee8b-9eab-4d1f-a785-5515f71339c6">

3. The user can try to edit by double clicking the cell of the desired label or clicking the pencil icon, however changes are not reflected on the UI and database
<img width="1166" alt="Screenshot 2024-01-26 at 11 04 24 PM" src="https://github.com/WillTrem/UInnovate/assets/74876532/b151f819-0acd-4cd3-a741-a8cd0bde04ad">


Multiple functionalities are missing such as editing the label and reflecting the changes onto the UI and database. Being able to delete the label, and the modal used to add labels need to be added because it's currently a window prompt. 