### PR TITLE
180 export import i18n configs

### DIFF
--- a/database/meta.sql
+++ b/database/meta.sql
@@ -249,33 +249,29 @@ DECLARE
     i18n_keys_json json;
     i18n_values_json json;
 BEGIN
-    SELECT COALESCE(json_agg(row_to_json(lang)), '[]') INTO i18n_json
-    -- Construct the JSON object using the i18n_languages 
+    SELECT COALESCE(json_agg(row_to_json(lang)), '[]') INTO i18n_languages_json
     FROM (
         SELECT id, language_code, language_name
         FROM meta.i18n_languages
     ) lang;
-    -- Construct the JSON object using the i18n_keys
-    SELECT json_agg(row_to_json(keys)) INTO i18n_json
+
+    SELECT COALESCE(json_agg(row_to_json(keys)), '[]') INTO i18n_keys_json
     FROM (
         SELECT id, key_code, is_default
         FROM meta.i18n_keys
     ) keys;
-    -- Construct the JSON object using the i18n_values
-    SELECT json_agg(row_to_json(values)) INTO i18n_json
+
+    SELECT COALESCE(json_agg(row_to_json(values)), '[]') INTO i18n_values_json
     FROM (
         SELECT id, language_id, key_id, value
         FROM meta.i18n_values
     ) values;
 
-    -- Combine the JSON objects into a single JSON object
-    i18n_json = json_build_object(
+    RETURN json_build_object(
         'languages', i18n_languages_json,
         'keys', i18n_keys_json,
         'values', i18n_values_json
     );
-
-    RETURN i18n_json;
 END;
 $BODY$;
 

--- a/scripting/export_i18n_config.sh
+++ b/scripting/export_i18n_config.sh
@@ -4,20 +4,17 @@ source ../.env
 # Define the output JSON file
 output_file="i18n_configurations.json"
 
+# Define the endpoint and the function to call
+POSTGREST_ENDPOINT="http://localhost:3000"
+FUNCTION_ENDPOINT="$POSTGREST_ENDPOINT/rpc/export_i18n_to_json"
+
 DB_CONTAINER_NAME="db"
 DB_USER=$POSTGRES_USER
 DB_PASS=$POSTGRES_PASSWORD
 DB_NAME=$POSTGRES_DB_NAME
 
-# 1st way not working
-# psql -h $DB_CONTAINER_NAME -U "$DB_USER" -d "$DB_NAME" -c "SELECT meta.export_i18n_to_json();" -t -o "$output_file"
-
-# 2nd way not working
-# docker exec -i $DB_CONTAINER psql -tA -U "$DB_USER" -d "$DB_NAME" -c "SELECT meta.export_i18n_to_json();" > "$output_file"
-
-# 3rd way not working 
-# psql -U $DB_USER -d $DB_NAME -t -c "SELECT meta.export_i18n_to_json();" > $output_file
+# Call the function directly
+curl -s "$FUNCTION_ENDPOINT" \
+ -X POST -H "Content-Profile: meta" -H "Content-Type: application/json" > "$output_file"
 
 echo "i18n configurations have been exported to $output_file"
-
-

--- a/scripting/export_i18n_config.sh
+++ b/scripting/export_i18n_config.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+source ../.env
+
+# Define the output JSON file
+output_file="i18n_configurations.json"
+
+DB_CONTAINER_NAME="db"
+DB_USER=$POSTGRES_USER
+DB_PASS=$POSTGRES_PASSWORD
+DB_NAME=$POSTGRES_DB_NAME
+
+# 1st way not working
+# psql -h $DB_CONTAINER_NAME -U "$DB_USER" -d "$DB_NAME" -c "SELECT meta.export_i18n_to_json();" -t -o "$output_file"
+
+# 2nd way not working
+# docker exec -i $DB_CONTAINER psql -tA -U "$DB_USER" -d "$DB_NAME" -c "SELECT meta.export_i18n_to_json();" > "$output_file"
+
+# 3rd way not working 
+# psql -U $DB_USER -d $DB_NAME -t -c "SELECT meta.export_i18n_to_json();" > $output_file
+
+echo "i18n configurations have been exported to $output_file"
+
+

--- a/scripting/export_i18n_config.sh
+++ b/scripting/export_i18n_config.sh
@@ -8,13 +8,8 @@ output_file="i18n_configurations.json"
 POSTGREST_ENDPOINT="http://localhost:3000"
 FUNCTION_ENDPOINT="$POSTGREST_ENDPOINT/rpc/export_i18n_to_json"
 
-DB_CONTAINER_NAME="db"
-DB_USER=$POSTGRES_USER
-DB_PASS=$POSTGRES_PASSWORD
-DB_NAME=$POSTGRES_DB_NAME
-
 # Call the function directly
 curl -s "$FUNCTION_ENDPOINT" \
- -X POST -H "Content-Profile: meta" -H "Content-Type: application/json" > "$output_file"
+    -X POST -H "Content-Profile: meta" -H "Content-Type: application/json" > "$output_file"
 
 echo "i18n configurations have been exported to $output_file"

--- a/scripting/import_i18n_from_json.sh
+++ b/scripting/import_i18n_from_json.sh
@@ -4,14 +4,13 @@ source ../.env
 # Define the input JSON file
 input_file="i18n_configurations.json"
 
-DB_CONTAINER="db"
-DB_USER=$POSTGRES_USER
-DB_PASS=$POSTGRES_PASSWORD
-DB_NAME=$POSTGRES_DB_NAME
+# Define the endpoint and the function to call
+POSTGREST_ENDPOINT="http://localhost:3000"
+FUNCTION_ENDPOINT="$POSTGREST_ENDPOINT/rpc/import_i18n_from_json"
 
-# Read the JSON file content
-json_data=$(<"$input_file")
+# Call the function directly
+curl -s "$FUNCTION_ENDPOINT" \
+    -X POST -H "Content-Profile: meta" -H "Content-Type: application/json" \
+    -d @"$input_file"
 
-docker exec -i $DB_CONTAINER psql -tA -U "$DB_USER" -d "$DB_NAME" -c "SELECT meta.import_i18n_from_json('$json_data')"
-
-echo "i18n configurations have been imported from $input_file" 
+echo "Import completed from $input_file. The configuration is saved in the database"

--- a/scripting/import_i18n_from_json.sh
+++ b/scripting/import_i18n_from_json.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+source ../.env
+
+# Define the input JSON file
+input_file="i18n_configurations.json"
+
+DB_CONTAINER="db"
+DB_USER=$POSTGRES_USER
+DB_PASS=$POSTGRES_PASSWORD
+DB_NAME=$POSTGRES_DB_NAME
+
+# Read the JSON file content
+json_data=$(<"$input_file")
+
+docker exec -i $DB_CONTAINER psql -tA -U "$DB_USER" -d "$DB_NAME" -c "SELECT meta.import_i18n_from_json('$json_data')"
+
+echo "i18n configurations have been imported from $input_file" 


### PR DESCRIPTION
Adding the export/import feature of i18n configurations. Any information stored into the languages, keys, and values tables will be exported onto the json file and any information added to the json will be imported to the database via the import stored procedure.

1. You can test the export, in the scripting folder via the command
```bash
cd scripting
./export_i18n_config.sh  
```

- After running the script, a new file will be automatically created into the scripting folder ``i18n_configurations.json``

2. To test that the import is working you can add an extra field in the keys table via the json file: ``i18n_configurations.json``
```bash
{"languages" : [], "keys" : [{"id":1,"key_code":"appconfig_properties","is_default":true}, {"id":2,"key_code":"appconfig_values","is_default":true}, {"id":3,"key_code":"availability_status","is_default":true}, {"id":4,"key_code":"company","is_default":true}, {"id":5,"key_code":"contact","is_default":true}, {"id":6,"key_code":"env_vars","is_default":true}, {"id":7,"key_code":"i18n_keys","is_default":true}, {"id":8,"key_code":"i18n_languages","is_default":true}, {"id":9,"key_code":"i18n_values","is_default":true}, {"id":10,"key_code":"job","is_default":true}, {"id":11,"key_code":"job_run_details","is_default":true}, {"id":12,"key_code":"purchase_order","is_default":true}, {"id":13,"key_code":"purchase_order_line_item","is_default":true}, {"id":14,"key_code":"quotation","is_default":true}, {"id":15,"key_code":"quotation_line_item","is_default":true}, {"id":16,"key_code":"scripts","is_default":true}, {"id":17,"key_code":"tool","is_default":true}, {"id":18,"key_code":"tool_restock_request","is_default":true}, {"id":19,"key_code":"tool_type","is_default":true}, {"id":20,"key_code":"unit","is_default":true}, {"id":21,"key_code":"unit_calibration_certificate","is_default":true}, {"id":22,"key_code":"unit_recalibration_flag","is_default":true}, {"id":23,"key_code":"unit_recalibration_schedule","is_default":true}, {"id":24,"key_code":"unit_recalibration_schedule_type","is_default":true}, {"id":25,"key_code":"unit_recalibration_status","is_default":true}, {"id":26,"key_code":"unit_scheduler","is_default":true}, {"id":27,"key_code":"users","is_default":true}, {"id":28,"key_code":"meta","is_default":true}, {"id":29,"key_code":"public","is_default":true}, {"id":30,"key_code":"authentication","is_default":true}, {"id":31,"key_code":"postgrest","is_default":true}, {"id":32,"key_code":"cron","is_default":true}, {"id":33,"key_code":"app_rentals","is_default":true}, {"id":34,"key_code":"blablabla","is_default":true}], "values" : []}
```

- **Notice my last value added** 
``{"id":34,"key_code":"blablabla","is_default":true}``

<img width="536" alt="Screenshot 2024-02-03 at 7 57 31 PM" src="https://github.com/WillTrem/UInnovate/assets/74876532/ce4884f4-48c3-4d38-9204-4283f65682aa">

- Once running the import script, it should be added onto the i18n_keys table on pgadmin


3. You can test the import, in the scripting folder via the command
```bash
cd scripting
./import_i18n_from_json.sh
```


Originally my export function had an issue but thanks to @SamRfk, it was fixed.