### PR TITLE
Increasing testing coverage for InternationalizationTab

### DIFF
--- a/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
@@ -172,23 +172,25 @@ const InternationalizationTab = () => {
     return (
         <div>
             <div>
-                <Button
-                    onClick={handleAddLanguage}
-                    style={buttonStyle}
-                    variant="contained"
-                >
+            <Button
+                data-testid="add-language-button" 
+                onClick={handleAddLanguage}
+                style={buttonStyle}
+                variant="contained"
+            >
                     Add Language
                 </Button>
                 <Button
                     style={buttonStyle}
                     variant="contained"
+                    data-testid="refresh-button"
                 >
                     Refresh
                 </Button>
             </div>
 
             <div style={{ maxHeight: '700px', overflowY: 'auto' }}> {/* Set max height and enable vertical scrolling */}
-                <TableComponent bordered>
+                <TableComponent bordered data-testid="table-component">
                     <thead>
                         <tr>
                             <th>Label</th>
@@ -221,12 +223,13 @@ const InternationalizationTab = () => {
                     variant="contained"
                     style={buttonStyle}
                     onClick={handleAddRowClick} 
+                    data-testid="add-label-button"
                 >
                     <IoMdAddCircle className="button-icon" /> 
                 </Button>
             </div>
 
-            <Modal show={showModalAddLanguage} onHide={handleClose}>
+            <Modal show={showModalAddLanguage} onHide={handleClose} data-testid="add-language-modal">
                 <Modal.Header>
                     <Modal.Title>Add New Language</Modal.Title>
                 </Modal.Header>
@@ -270,7 +273,7 @@ const InternationalizationTab = () => {
                 </Modal.Footer>
             </Modal>
 
-            <Modal show={showModalAddLabel} onHide={handleClose}>
+            <Modal show={showModalAddLabel} onHide={handleClose} data-testid="add-label-modal">
                 <Modal.Header>
                     <Modal.Title>Add New Label</Modal.Title>
                 </Modal.Header>

--- a/UInnovateApp/src/tests/components/settingsPage/InternationalizationTab.test.tsx
+++ b/UInnovateApp/src/tests/components/settingsPage/InternationalizationTab.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import InternationalizationTab from "../../../components/settingsPage/InternationalizationTab"
+import { describe, expect } from "vitest";
+import { Middleware, Store } from "@reduxjs/toolkit";
+import configureStore from "redux-mock-store";
+import { Role } from "../../../redux/AuthSlice";
+import { ConfigProvider } from "../../../contexts/ConfigContext";
+import { Provider } from "react-redux";
+
+describe("InternationalizationTab component", () => {
+	const initialState = {
+		schema: { schema_name: "application" },
+		script_table: { table_name: "script_mock" },
+		auth: { role: Role.ADMIN, user: "admin", token: "token" } 
+	};
+	const middlewares: Middleware[] = [];
+	const mockStore = configureStore(middlewares);
+	let store: Store;
+
+
+	it("renders the component", () => {
+		store = mockStore(initialState);
+		render(
+			<ConfigProvider>
+				<Provider store={store}>
+					<InternationalizationTab />
+				</Provider>
+			</ConfigProvider>
+		);
+	}),
+  it("renders the table component", async () => {
+    render(<ConfigProvider>
+      <Provider store={store}>
+        <InternationalizationTab />
+      </Provider>
+    </ConfigProvider>);
+    const tableElement = screen.getByTestId('table-component');
+    expect(tableElement).toBeInTheDocument();
+  }),
+		it("displays the add language modal when the add language button is clicked", async () => {
+			const { getByText } = render(<ConfigProvider>
+				<Provider store={store}>
+					<InternationalizationTab />
+				</Provider>
+			</ConfigProvider>);
+			const button = getByText("Add Language");
+			fireEvent.click(button);
+
+			await waitFor(() => {
+				const modalElement = screen.getByTestId('add-language-modal');
+				expect(modalElement).toBeInTheDocument();
+			});
+		}),
+		it("closes the add language modal when the cancel button is clicked", async () => {
+			render(<ConfigProvider>
+				<Provider store={store}>
+					<InternationalizationTab />
+				</Provider>
+			</ConfigProvider>);
+			const button = screen.getByText("Add Language");
+			fireEvent.click(button);
+
+			await waitFor(() => {
+				const modalElement = screen.getByTestId('add-language-modal');
+				expect(modalElement).toBeInTheDocument();
+			});
+
+			const closeButton = screen.getByText("Close");
+
+			fireEvent.click(closeButton);
+
+			await waitFor(() => {
+				const modalElement = screen.queryByTestId('add-language-modal');
+				expect(modalElement).not.toBeInTheDocument();
+			});
+		}),
+    it("When clicking the save button from the add language modal, the language should be saved ", async () => {
+      render(<ConfigProvider>
+        <Provider store={store}>
+          <InternationalizationTab />
+        </Provider>
+      </ConfigProvider>);
+      const button = screen.getByText("Add Language");
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        const modalElement = screen.getByTestId('add-language-modal');
+        expect(modalElement).toBeInTheDocument();
+      });
+
+      const saveButton = screen.getByText("Save");
+
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        const modalElement = screen.queryByTestId('add-language-modal');
+        expect(modalElement).not.toBeInTheDocument();
+      });
+    }),
+    it("displays the add label modal when the add label icon button is clicked", async () => {
+      render(<ConfigProvider>
+        <Provider store={store}>
+          <InternationalizationTab />
+        </Provider>
+      </ConfigProvider>);
+      const button = screen.getByTestId("add-label-button");  
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        const modalElement = screen.getByTestId('add-label-modal');
+        expect(modalElement).toBeInTheDocument();
+      });
+    }),
+    it("closes the add label modal when the cancel button is clicked", async () => {
+      render(<ConfigProvider>
+        <Provider store={store}>
+          <InternationalizationTab />
+        </Provider>
+      </ConfigProvider>);
+      const button = screen.getByTestId("add-label-button");
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        const modalElement = screen.getByTestId('add-label-modal');
+        expect(modalElement).toBeInTheDocument();
+      });
+
+      const closeButton = screen.getByText("Close");
+
+      fireEvent.click(closeButton);
+
+      await waitFor(() => {
+        const modalElement = screen.queryByTestId('add-label-modal');
+        expect(modalElement).not.toBeInTheDocument();
+      });
+    }),
+    it("When clicking the save button from the add label modal, the label should be saved ", async () => {
+      render(<ConfigProvider>
+        <Provider store={store}>
+          <InternationalizationTab />
+        </Provider>
+      </ConfigProvider>);
+      const button = screen.getByTestId("add-label-button");
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        const modalElement = screen.getByTestId('add-label-modal');
+        expect(modalElement).toBeInTheDocument();
+      });
+
+      const saveButton = screen.getByText("Save");
+
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        const modalElement = screen.queryByTestId('add-label-modal');
+        expect(modalElement).not.toBeInTheDocument();
+      });
+    }),
+    it("Refresh button is clickable", async () => {
+      render(<ConfigProvider>
+        <Provider store={store}>
+          <InternationalizationTab />
+        </Provider>
+      </ConfigProvider>);
+      const button = screen.getByTestId("refresh-button");
+      fireEvent.click(button);
+    })
+})


### PR DESCRIPTION
## Increasing the testing for i18n tab

### There should be 9 tests that pass in that file
<img width="804" alt="Screenshot 2024-02-10 at 10 21 07 AM" src="https://github.com/WillTrem/UInnovate/assets/74876532/8da3290d-0ce9-4864-ad0d-060c35cb054f">

### How to test

For all tests,

```bash
npm run test:unit
```

If you wanna isolate to see only tests from the InternationalizationTab

1. While running ``pm run test:unit``, open the file: ``InternationalizationTab.test.tsx``
2. Save the file, it should show you only the tests  for i18n
