### PR TITLE
Adding Languages as Dropdown from a library

### DIFF
--- a/UInnovateApp/package-lock.json
+++ b/UInnovateApp/package-lock.json
@@ -22,6 +22,7 @@
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "import-single-ts": "^1.0.3",
+        "iso-639-1": "^3.1.1",
         "isolated-vm": "^4.7.2",
         "mui-tel-input": "^5.0.0",
         "mui-tiptap": "^1.8.6",
@@ -9646,6 +9647,14 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/iso-639-1": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-3.1.1.tgz",
+      "integrity": "sha512-5gT/IjVnt/ZDkAzd2pseoxlI5iAgxz/2ZJIrtdyFu9iqeK5/NpgowYwsFy1p5x6+jjG+r7vmik7r4XImSpaSOw==",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/isobject": {
       "version": "3.0.1",

--- a/UInnovateApp/package.json
+++ b/UInnovateApp/package.json
@@ -31,6 +31,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "import-single-ts": "^1.0.3",
+    "iso-639-1": "^3.1.1",
     "isolated-vm": "^4.7.2",
     "mui-tel-input": "^5.0.0",
     "mui-tiptap": "^1.8.6",

--- a/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
@@ -228,6 +228,7 @@ const InternationalizationTab = () => {
                         onClick={handleDropdownLanguages}
                         variant="outlined"
                         label="Default Language"
+                        defaultValue=""
                     >
                         {languages.map(language => (
                             <MenuItem key={language} value={language}>{language}</MenuItem>
@@ -253,6 +254,7 @@ const InternationalizationTab = () => {
                             if (translation) {
                                 return (
                                     <TranslationTableRow
+                                        getTranslations={getTranslations}
                                         key={idx}
                                         keyCode={translation["key_code"] as string}
                                         value={translation["value"] as string}
@@ -294,7 +296,7 @@ const InternationalizationTab = () => {
                                 label="Add Language"
                             >
                                 {isoLanguages.getAllNames().map(language => (
-                                    <MenuItem value={language}>{language}</MenuItem>
+                                    <MenuItem key={language} value={language}>{language}</MenuItem>
                                 ))}
                             </Select>
                         </FormControl>
@@ -357,44 +359,16 @@ const InternationalizationTab = () => {
 };
 
 interface TranslationTableRowProps {
-    id?: string,
+    getTranslations: () => void,
     keyCode?: string,
     value?: string,
     is_default?: boolean,
     onEdit: (keyCode: string, newValue: string) => void;
 }
 
-const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ id, keyCode, value, is_default, onEdit }) => {
+const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslations, keyCode, value, is_default, onEdit }) => {
     const [isEditing, setIsEditing] = useState(false);
     const [editedValue, setEditedValue] = useState(value || "");
-
-    const [translations, setTranslations] = useState<Row[]>([]);
-
-    const getTranslations = async () => {
-        try {
-            const data_accessor: DataAccessor = vmd.getViewRowsDataAccessor(
-                "meta",
-                "i18n_translations"
-            );
-
-            const rows = await data_accessor.fetchRows();
-            
-            if (rows) {
-                console.log("Fetched rows:", rows);
-                const translationsWithIsDefault = rows.map(row => ({
-                    ...row,
-                    is_default: row.is_default || false,
-                }));
-
-                setTranslations(translationsWithIsDefault);
-            }
-        } catch (error) {
-            console.error('Error fetching translations:', error);
-        }
-    };
-
-    useEffect(() => {
-    }, []);
 
     const handleDoubleClick = () => {
         if (!is_default) {

--- a/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
@@ -26,6 +26,9 @@ const addLabelButtonStyle = {
     
 };
 
+const language_code_column_name = "language_code";
+const order_by_column = "translation_id";
+
 const InternationalizationTab = () => {
     const [showModalAddLanguage, setshowModalAddLanguage] = useState<boolean>(false);
     const [showModalAddLabel, setshowModalAddLabel] = useState<boolean>(false);
@@ -35,6 +38,8 @@ const InternationalizationTab = () => {
     const [languages, setLanguages] = useState<string[]>([]); 
 
     const [newLabelName, setNewLabelName] = useState<string>(''); 
+
+    const [selectedLanguage, setSelectedLanguage] = useState<string>("en");
     
     const getTranslations = async () => {
         try {
@@ -42,7 +47,7 @@ const InternationalizationTab = () => {
                 "meta",
                 "i18n_translations"
             );
-            const rows = await data_accessor.fetchRows();
+            const rows = await data_accessor.fetchRowsByColumnValues(language_code_column_name, selectedLanguage, order_by_column);
             if (rows) {
                 console.log("Fetched rows:", rows);
 
@@ -81,7 +86,7 @@ const InternationalizationTab = () => {
         getLanguages();
     }, []);
 
-    const handleAddLanguage = () => {
+    const showAddLanguage = () => {
         setshowModalAddLanguage(true);
     };
 
@@ -192,9 +197,13 @@ const InternationalizationTab = () => {
         await getLanguages();
     };
 
-    const handleLanguageChange = (event: SelectChangeEvent<string>) => {
+    const handleSelectedNewLanguage = (event: SelectChangeEvent<string>) => {
         setNewLanguageName(event.target.value as string);
         setNewLanguageCode(isoLanguages.getCode(event.target.value as string));
+    };
+
+    const handleSelectedLanguage = (event: SelectChangeEvent<string>) => {
+        setSelectedLanguage(event.target.value as string);
     };
 
     return (
@@ -202,7 +211,7 @@ const InternationalizationTab = () => {
             <div>
             <Button
                 data-testid="add-language-button" 
-                onClick={handleAddLanguage}
+                onClick={showAddLanguage}
                 style={buttonStyle}
                 variant="contained"
             >
@@ -224,11 +233,11 @@ const InternationalizationTab = () => {
                     <Select
                         labelId="default-language-label"
                         name="Default Language"
-                        // onChange={() => handleDefaultLanguageChange()}
+                        onChange={handleSelectedLanguage}
                         onClick={handleDropdownLanguages}
                         variant="outlined"
                         label="Default Language"
-                        defaultValue=""
+                        defaultValue=''
                     >
                         {languages.map(language => (
                             <MenuItem key={language} value={language}>{language}</MenuItem>
@@ -242,11 +251,7 @@ const InternationalizationTab = () => {
                     <thead>
                         <tr>
                             <th>Label</th>
-                            {/* TODO: Fix the default language, the comments will be left for now*/}
-                            <th>{`LANG:${languages[0]}`}</th>
-                            {/* {languages.map(language => (
-                                <th key={language}>{`LANG:${language}`}</th>
-                            ))} */}
+                            <th>{`LANG:${selectedLanguage}`}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -291,7 +296,7 @@ const InternationalizationTab = () => {
                             <Select
                                 labelId="add-language"
                                 value={newLanguageName}
-                                onChange={handleLanguageChange}
+                                onChange={handleSelectedNewLanguage}
                                 variant="outlined"
                                 label="Add Language"
                             >

--- a/UInnovateApp/src/styles/InternationalizationTab.css
+++ b/UInnovateApp/src/styles/InternationalizationTab.css
@@ -1,0 +1,16 @@
+div.default-language-input {
+    display: flex;
+    flex-direction: row;
+    width: 200px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
+td.container-labels {
+    display: flex;
+    align-items: center;
+}
+
+.icon-lock {
+    color: #C0C0C0;
+}

--- a/UInnovateApp/src/virtualmodel/DataAccessor.tsx
+++ b/UInnovateApp/src/virtualmodel/DataAccessor.tsx
@@ -41,6 +41,30 @@ export class DataAccessor {
     }
   }
 
+  // Method to fetch rows from a table or view by column values
+  // return type: Row[]
+  async fetchRowsByColumnValues(column_name: string, column_value: string, order_by_column: string | undefined, signal?: AbortSignal | undefined) {
+    try {
+      const rows: Row[] = [];
+      this.data_url = this.data_url + `?${column_name}=eq.${column_value}`;
+      if (order_by_column) {
+        this.data_url = this.data_url + `&order=${order_by_column}.asc`;
+      }
+      const response = await axiosCustom.get(this.data_url, {
+        signal: signal,
+        headers: this.headers,
+      });
+
+      response.data.forEach((row: Row) => {
+        rows.push(row);
+      });
+
+      return rows;
+    } catch (error) {
+      console.error("Could not fetch data:", error);
+    }
+  }
+
   // Method to add a row to a table
   // return type: AxiosResponse
   async addRow() {

--- a/database/meta_data.sql
+++ b/database/meta_data.sql
@@ -75,6 +75,9 @@ INSERT INTO meta.i18n_keys (key_code, is_default)
 SELECT DISTINCT "schema", true
 FROM meta.schemas;
 
+-- Insert the default language into the i18n_languages table
+INSERT INTO meta.i18n_languages (language_code, language_name) 
+VALUES ('en', 'English');
 
 
 


### PR DESCRIPTION
There has been a few changes regarding adding new languages to i18n and selecting a default value.

Previously, it used to be via manual input of adding the language name and language code, however it has been changed to a dropdown and there was the default language dropdown added.

## Steps
1. Click `Add Language`
<img width="1080" alt="Screenshot 2024-02-18 at 10 02 10 PM" src="https://github.com/WillTrem/UInnovate/assets/74876532/3994e6d9-29ec-4f59-8478-64ffb7b5019e">

<br></br>
2. Select a language, for example, `Bulgarian`
<img width="861" alt="Screenshot 2024-02-18 at 10 02 59 PM" src="https://github.com/WillTrem/UInnovate/assets/74876532/84e6e69e-c179-4330-8a20-d803a5eea681">


<br></br>
3. For now, the languages added won't be directly displayed on the UI, since only the default language will be displayed (still a work in progress). Therefore, to see that the language has been added successfully, you can check the` i18n_languages `table.


<img width="585" alt="Screenshot 2024-02-18 at 10 06 18 PM" src="https://github.com/WillTrem/UInnovate/assets/74876532/44336fac-eeba-4f44-9d3b-a90092552c4a">

<br></br>
4. Adding a `default language 'bg' `via the default language dropdown should work as depicted on the following screenshot.
![image](https://github.com/WillTrem/UInnovate/assets/74876532/706d5475-83f1-4e74-a234-0ffbb6d20359)


## NOTE
- I'm adding a new package, hence once merged, you'll need to update with `npm install`.
https://www.npmjs.com/package/iso-639-1
- Bug #283 was fixed with this PR
- Added styling to some components
