### PR TITLE
142 - Roles View + Roles Refactor

### DIFF
--- a/UInnovateApp/src/components/NavBar.tsx
+++ b/UInnovateApp/src/components/NavBar.tsx
@@ -15,6 +15,7 @@ import {Tooltip, Zoom} from '@mui/material'
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import LoginIcon from '@mui/icons-material/Login';
 import LogoutIcon from '@mui/icons-material/Logout';
+import { setLoading } from '../redux/LoadingSlice';
 
 interface NavBarProps {
   showSchemaFilter?: boolean;
@@ -27,8 +28,10 @@ export function NavBar({ showSchemaFilter = true }: NavBarProps) {
   const handleClose = () => setShowSignupModal(false);
   const handleShow = () => setShowSignupModal(true);
   const handleLogout = () => {
+    dispatch(setLoading(true));
     dispatch(logOut());
     navigate('/');
+    dispatch(setLoading(false));
   }
 
 

--- a/UInnovateApp/src/components/NavBar.tsx
+++ b/UInnovateApp/src/components/NavBar.tsx
@@ -16,6 +16,7 @@ import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import LoginIcon from '@mui/icons-material/Login';
 import LogoutIcon from '@mui/icons-material/Logout';
 import { setLoading } from '../redux/LoadingSlice';
+import vmd from '../virtualmodel/VMD';
 
 interface NavBarProps {
   showSchemaFilter?: boolean;
@@ -30,8 +31,10 @@ export function NavBar({ showSchemaFilter = true }: NavBarProps) {
   const handleLogout = () => {
     dispatch(setLoading(true));
     dispatch(logOut());
+    vmd.refetchSchemas().then(() => {
+      dispatch(setLoading(false));
+    })
     navigate('/');
-    dispatch(setLoading(false));
   }
 
 

--- a/UInnovateApp/src/components/NavBar.tsx
+++ b/UInnovateApp/src/components/NavBar.tsx
@@ -23,7 +23,7 @@ interface NavBarProps {
 }
 export function NavBar({ showSchemaFilter = true }: NavBarProps) {
   const [showSignupModal, setShowSignupModal] = useState(false);
-  const {user: loggedInUser, role }: AuthState = useSelector((state: RootState) => state.auth);
+  const {user: loggedInUser, dbRole }: AuthState = useSelector((state: RootState) => state.auth);
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const handleClose = () => setShowSignupModal(false);
@@ -70,7 +70,7 @@ export function NavBar({ showSchemaFilter = true }: NavBarProps) {
             {( LOGIN_BYPASS || loggedInUser ) &&
             <>
             {/* Hides the Settings page link for user role */}
-            <Nav.Link as={Link} to="/settings" style={{ fontSize: "25px" }} hidden={role === Role.USER}>
+            <Nav.Link as={Link} to="/settings" style={{ fontSize: "25px" }} hidden={dbRole === Role.USER}>
               Settings
             </Nav.Link></>
             }

--- a/UInnovateApp/src/components/PersistLogin.tsx
+++ b/UInnovateApp/src/components/PersistLogin.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { DecodedToken, logIn, updateDefaultRole, updateSchemaRoles } from "../redux/AuthSlice";
 import vmd from "../virtualmodel/VMD";
 import { setLoading } from "../redux/LoadingSlice";
-import { getDefaultRole, getSchemaRoles } from "./settingsPage/Users/RolesTab";
+import { getDefaultRole, getSchemaRoles } from "../helper/RolesHelpers";
 import { jwtDecode } from "jwt-decode";
 
 const PersistLogin: React.FC = () => {

--- a/UInnovateApp/src/components/PersistLogin.tsx
+++ b/UInnovateApp/src/components/PersistLogin.tsx
@@ -1,27 +1,35 @@
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../redux/Store";
 import { useEffect } from "react";
-import { logIn } from "../redux/AuthSlice";
+import { DecodedToken, logIn, updateDefaultRole, updateSchemaRoles } from "../redux/AuthSlice";
 import vmd from "../virtualmodel/VMD";
 import { setLoading } from "../redux/LoadingSlice";
+import { getDefaultRole, getSchemaRoles } from "./settingsPage/Users/RolesTab";
+import { jwtDecode } from "jwt-decode";
 
-const PersistLogin:React.FC = () => {
+const PersistLogin: React.FC = () => {
 	const dispatch = useDispatch();
 	const token = useSelector((state: RootState) => state.auth.token);
-	
+
 	useEffect(() => {
-		if(!token){
+		if (!token) {
 			dispatch(setLoading(true));
 			const refreshTokenFuncAccessor = vmd.getFunctionAccessor('meta', 'token_refresh');
-			refreshTokenFuncAccessor.executeFunction({withCredentials: true}).then(async (response) => {
+			refreshTokenFuncAccessor.executeFunction({ withCredentials: true }).then(async (response) => {
 				const token = response.data.token;
-				dispatch(logIn(token)); 
+				dispatch(logIn(token));
 				await vmd.refetchSchemas();
+				const { email } = jwtDecode(token) as DecodedToken;
+				const schemaRoles = await getSchemaRoles(email);
+				dispatch(updateSchemaRoles(schemaRoles));
+				
+				const defaultRole = await getDefaultRole(email);
+				dispatch(updateDefaultRole(defaultRole));
 			})
-			.catch((error) => {console.log(error.response.data.message)})
-			.finally(() => dispatch(setLoading(false)));
+				.catch((error) => { console.log(error.response.data.message) })
+				.finally(() => dispatch(setLoading(false)));
 		}
-	},[])
+	}, [])
 	return <></>
 }
 export default PersistLogin;

--- a/UInnovateApp/src/components/settingsPage/DisplayTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/DisplayTab.tsx
@@ -7,26 +7,10 @@ import ConfigurationSaver from "./ConfigurationSaver";
 import vmd from "../../virtualmodel/VMD";
 import { useSelector } from "react-redux";
 import { RootState } from "../../redux/Store";
-import { Box, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent, Typography } from "@mui/material";
-import React, { useState } from "react";
-import { LOGIN_BYPASS } from "../../redux/AuthSlice";
 
 const DisplayTab = () => {
 
-  const { user, schema_access } = useSelector((state: RootState) => state.auth);
-  const schemas = [
-    ...new Set(vmd.getApplicationSchemas()
-      .map((schema) => schema.schema_name)
-      .filter((schema_name) => {
-        // Ensures that on LOGIN_BYPASS without being logged in, all the schemas show
-        if ((LOGIN_BYPASS && user === null) || schema_access.includes(schema_name)) {
-          return schema_name;
-        }
-      })),
-  ];
-  // Prevents error when schema_access has a length of 0
-  const initialSelectedSchema = schemas.length === 0 ? "" : schemas[0]
-  const [selectedSchema, setSelectedSchema] = useState(initialSelectedSchema);
+ const selectedSchema = useSelector((state: RootState) => state.schema.value);
 
   // Only show tables of the selected schema
   const tables = vmd.getSchema(selectedSchema)?.tables;
@@ -34,37 +18,15 @@ const DisplayTab = () => {
     <TableItem key={table.table_name} table={table} />
   ));
 
-  const handleSchemaChange = (event: SelectChangeEvent) => {
-    setSelectedSchema(event.target.value);
-  };
 
   return (
     <div>
       
       <ConfigurationSaver />
-      {schemas.length !== 0 ?
       <Tab.Container>
         <Row>
           <Col sm={3}>
-              <Box display="flex" gap="1rem" alignItems={"center"} >
                 <h4 style={{ marginBottom: 0 }}>Tables</h4>
-                <FormControl fullWidth disabled={schemas.length === 0}>
-                  <InputLabel id="schema-label">Schema</InputLabel>
-                  <Select
-                    labelId="schema-label"
-                    name="schema"
-                    value={selectedSchema}
-                    onChange={(event) => handleSchemaChange(event)}
-                    variant="outlined"
-                    label="Schema"
-                    size="small"
-                  >
-                    {schemas.map((schema) => {
-                      return <MenuItem key={schema} value={schema}>{schema}</MenuItem>
-                    })};
-                  </Select>
-                </FormControl>
-              </Box>
             <Nav variant="pills" className="flex-column">
               {tables?.map(({ table_name }) => {
                 return (
@@ -93,8 +55,6 @@ const DisplayTab = () => {
           </Col>
         </Row>
       </Tab.Container>
-      :
-      <Typography variant="body1">You don't have access to any tables.</Typography>}
     </div>
   );
 };

--- a/UInnovateApp/src/components/settingsPage/SignupModal.tsx
+++ b/UInnovateApp/src/components/settingsPage/SignupModal.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from "react-router-dom";
 import { Visibility, VisibilityOff, Check, Close, NavigateNext, NavigateBefore } from '@mui/icons-material';
 import { green, grey } from '@mui/material/colors';
 import { ErrMsg } from "../../enums/ErrMsg";
+import { setLoading } from "../../redux/LoadingSlice";
 
 const LENGTH_REGEX = new RegExp(/.{8,}$/);
 const UPPERCASE_REGEX = new RegExp(/.*[A-Z]/);
@@ -157,13 +158,15 @@ const SignupModal: React.FC<Omit<ModalProps, 'children'>> = (props) => {
 			loginFunctionAccessor.executeFunction({ withCredentials: true })
 				// Logs in the user
 				.then(async (response) => {
+					dispatch(setLoading(true));
 					const token = response.data.token;
 					dispatch(logIn(token));
+					navigate('/');
 					await vmd.refetchSchemas();
 					// Closes the form
 					const dummyEvent = document.createEvent('MouseEvents');
 					handleCancel(dummyEvent as unknown as React.MouseEvent<HTMLButtonElement, MouseEvent>);
-					navigate('/');
+					dispatch(setLoading(false));
 				})
 				.catch(() => {
 					setPasswordError(ErrMsg.WRONG_PASSWORD);

--- a/UInnovateApp/src/components/settingsPage/SignupModal.tsx
+++ b/UInnovateApp/src/components/settingsPage/SignupModal.tsx
@@ -6,12 +6,13 @@ import { FunctionAccessor } from "../../virtualmodel/FunctionAccessor";
 import vmd from "../../virtualmodel/VMD";
 import validator from 'validator';
 import { useDispatch, useSelector } from "react-redux";
-import { logIn } from "../../redux/AuthSlice";
+import { logIn, updateDefaultRole, updateSchemaRoles } from "../../redux/AuthSlice";
 import { useNavigate } from "react-router-dom";
 import { Visibility, VisibilityOff, Check, Close, NavigateNext, NavigateBefore } from '@mui/icons-material';
 import { green, grey } from '@mui/material/colors';
 import { ErrMsg } from "../../enums/ErrMsg";
 import { setLoading } from "../../redux/LoadingSlice";
+import { getDefaultRole, getSchemaRoles } from "./Users/RolesTab";
 
 const LENGTH_REGEX = new RegExp(/.{8,}$/);
 const UPPERCASE_REGEX = new RegExp(/.*[A-Z]/);
@@ -62,7 +63,7 @@ const SignupModal: React.FC<Omit<ModalProps, 'children'>> = (props) => {
 	// Reset the inputValues state's values
 	const resetValues = () => setInputValues({});
 
-	function resetErrorMessages(){
+	function resetErrorMessages() {
 		//Reset Error Message states
 		setEmailError("");
 		setPasswordError("");
@@ -163,6 +164,12 @@ const SignupModal: React.FC<Omit<ModalProps, 'children'>> = (props) => {
 					dispatch(logIn(token));
 					navigate('/');
 					await vmd.refetchSchemas();
+					const schemaRoles = await getSchemaRoles(inputValues.email);
+					dispatch(updateSchemaRoles(schemaRoles));
+					
+					const defaultRole = await getDefaultRole(inputValues.email);
+					dispatch(updateDefaultRole(defaultRole));
+
 					// Closes the form
 					const dummyEvent = document.createEvent('MouseEvents');
 					handleCancel(dummyEvent as unknown as React.MouseEvent<HTMLButtonElement, MouseEvent>);

--- a/UInnovateApp/src/components/settingsPage/SignupModal.tsx
+++ b/UInnovateApp/src/components/settingsPage/SignupModal.tsx
@@ -12,7 +12,7 @@ import { Visibility, VisibilityOff, Check, Close, NavigateNext, NavigateBefore }
 import { green, grey } from '@mui/material/colors';
 import { ErrMsg } from "../../enums/ErrMsg";
 import { setLoading } from "../../redux/LoadingSlice";
-import { getDefaultRole, getSchemaRoles } from "./Users/RolesTab";
+import { getDefaultRole, getSchemaRoles } from "../../helper/RolesHelpers";
 
 const LENGTH_REGEX = new RegExp(/.{8,}$/);
 const UPPERCASE_REGEX = new RegExp(/.*[A-Z]/);

--- a/UInnovateApp/src/components/settingsPage/TableSelector.tsx
+++ b/UInnovateApp/src/components/settingsPage/TableSelector.tsx
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { Nav } from "react-bootstrap";
+import vmd from "../../virtualmodel/VMD";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/Store";
+
+interface SchemaTableSelectorProp {
+	setTable: React.Dispatch<React.SetStateAction<string>>;
+}
+const TableSelector = ({ setTable }: SchemaTableSelectorProp) => {
+	const selectedSchema = useSelector((state: RootState) => state.schema.value);
+
+	// Only show tables of the selected schema
+	const tables = vmd.getSchema(selectedSchema)?.tables;
+
+	useEffect(() => {
+		setTable('');
+	}, [])
+
+	const handleClick = (table_name: string): void => {
+		setTable(table_name);
+	}
+
+	return (
+		<>
+			<h4 style={{ marginBottom: 0 }}>Tables</h4>
+			<Nav variant="pills" className="flex-column">
+				{tables?.map(({ table_name }) => {
+					return (
+						<Nav.Item key={table_name} data-testid="table-setting-nav">
+							<Nav.Link eventKey={table_name} onClick={(e) => { e.preventDefault(); handleClick(table_name); }} >{table_name}</Nav.Link>
+						</Nav.Item>
+					);
+				})}
+			</Nav>
+		</>
+	)
+}
+
+export default TableSelector;

--- a/UInnovateApp/src/components/settingsPage/Users/AddUserModal.tsx
+++ b/UInnovateApp/src/components/settingsPage/Users/AddUserModal.tsx
@@ -1,15 +1,15 @@
 import { Box, Button, FormControl, InputLabel, MenuItem, Modal, ModalProps, Select, SelectChangeEvent, TextField, Typography } from "@mui/material"
 import React, { ReactNode, useEffect, useState } from "react"
 
-import "../../styles/Modals.css"
-import "../../styles/UserManagementTab.css"
-import vmd from "../../virtualmodel/VMD"
-import { Row } from "../../virtualmodel/DataAccessor"
-import MultiSelect from "./MultiSelect"
-import { FunctionAccessor } from "../../virtualmodel/FunctionAccessor"
-import { Role } from "../../redux/AuthSlice"
+import "../../../styles/Modals.css"
+import "../../../styles/UserManagementTab.css"
+import vmd from "../../../virtualmodel/VMD"
+import { Row } from "../../../virtualmodel/DataAccessor"
+import MultiSelect from "../MultiSelect"
+import { FunctionAccessor } from "../../../virtualmodel/FunctionAccessor"
+import { Role } from "../../../redux/AuthSlice"
 
-import { ErrMsg } from "../../enums/ErrMsg"
+import { ErrMsg } from "../../../enums/ErrMsg"
 import validator from "validator"
 import { AxiosError } from "axios"
 

--- a/UInnovateApp/src/components/settingsPage/Users/RolesTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/Users/RolesTab.tsx
@@ -148,7 +148,8 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({ user, schemas, schemaRole
 		</TableCell>
 		{schemas.map((schema) => {
 			return <TableCell key={schema}>
-				<FormControl fullWidth>
+				{user.schema_access && user.schema_access.includes(schema)
+				?<FormControl fullWidth>
 					<Select
 						name="role"
 						value={schemaRoles[schema] || ''}
@@ -164,47 +165,9 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({ user, schemas, schemaRole
 						{/* <MenuItem value={Role.ADMIN}>Admin</MenuItem> */}
 					</Select>
 				</FormControl>
+				:<Typography color={"grey"}>No Access</Typography>}
 			</TableCell>
 		})}
 	</TableRow>
 }
-/**
- * Function that obtains the schema roles for a given user
- * @returns SchemaRoles
- */
-export async function getSchemaRoles(user: string): Promise<SchemaRoles>
-{
-	const rolePerSchemaDA = vmd.getRowDataAccessor('meta', 'role_per_schema', 'user', user);
-	const rolePerSchemaResponse = await rolePerSchemaDA.fetchRows();
-	console.log(rolePerSchemaResponse);
-	if (rolePerSchemaResponse) {
-		const reducedRolePerSchema = rolePerSchemaResponse.reduce((obj, { schema, role }) => {
-			obj[schema] = role;
-			return obj;
-		}, {});
-		return reducedRolePerSchema
-	}else{
-		console.log('Failed to obtain the schema roles of user ' + user)
-		return {};
-	}
-}
-
-/**
- * Function that obtains the default role for a given user
- * @returns Role
- */
-export async function getDefaultRole(user: string): Promise<Role|null>
-{
-	const defaultRoleDA = vmd.getViewRowDataAccessor('meta', 'user_info', ['email'],[ user]);
-	const response = await defaultRoleDA.fetchRows();
-	if (response) {
-		console.log(response);
-		const defaultRole = response[0]['role']
-		return defaultRole as Role;
-	}else{
-		console.log('Failed to obtain the default role of user ' + user);
-		return null;
-	}
-}
-
 export default RolesTab;

--- a/UInnovateApp/src/components/settingsPage/Users/RolesTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/Users/RolesTab.tsx
@@ -1,36 +1,37 @@
+import "../../../styles/TableComponent.css"
 import { useState } from "react";
-import { Row } from "../../../virtualmodel/DataAccessor";
 import vmd, { UserData } from "../../../virtualmodel/VMD";
-import { Box, FormControl, InputLabel, MenuItem, Paper, Select, SelectChangeEvent, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TableRowProps } from "@mui/material";
+import { Box, FormControl, InputLabel, MenuItem, Paper, Select, SelectChangeEvent, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TableRowProps, fabClasses } from "@mui/material";
 import { useSelector } from "react-redux";
 import { RootState } from "../../../redux/Store";
 import { Role } from "../../../redux/AuthSlice";
-
 const RolesTab: React.FC = () => {
 	const users = useSelector((state: RootState) => state.userData.users)
 	const schemas: string[] = vmd.getApplicationSchemas().map((schema) => schema.schema_name);
-	// const schemas: string[] = ["Schema1","Schema1","Schema1","Schema1","Schema1","Schema1","Schema1","Schema1","Schema1","Schema1"]
-	
+	// const schemas: string[] = ["Schema1", "Schema1", "Schema1", "Schema1", "Schema1", "Schema1", "Schema1", "Schema1", "Schema1", "Schema1"]
 
-	return <Box paddingTop={2} alignContent={"center"}>
-		<TableContainer >
-			<Table sx={{width:"auto"}}>
-				<TableHead>
-					<TableRow>
-						<TableCell sx={{maxWidth: "15rem"}}>Users</TableCell>
-						<TableCell sx={{minWidth:"11rem", width:"11rem"}}>Default </TableCell>
-						{schemas.map((schema) => {
-							return <TableCell key={schema} sx={{minWidth:"11rem", width:"11rem"}}>{schema}</TableCell>
+
+	return <Box display="flex" justifyContent="center" paddingTop={2}  >
+		<Box sx={{ display: "inline-block", overflow: "auto", maxWidth: "100%", alignItems: "center" }}>
+			<TableContainer sx={{ display: "block", border: "thin solid grey" }} component={Box}>
+				<Table sx={{ minWidth: "max-content", borderCollapse: "separate", border: "none" }}>
+					<TableHead >
+						<TableRow>
+							<TableCell className="sticky-column-left" sx={{ maxWidth: "15rem", borderRight: "thin solid #e0e0e0", fontWeight: "Bold" }}>Users</TableCell>
+							<TableCell sx={{ minWidth: "11rem", width: "11rem", fontWeight: "Bold" }}>Default </TableCell>
+							{schemas.map((schema) => {
+								return <TableCell key={schema} sx={{ minWidth: "11rem", width: "11rem", fontWeight: "Bold" }}>{schema}</TableCell>
+							})}
+						</TableRow>
+					</TableHead>
+					<TableBody>
+						{users.map((user: UserData) => {
+							return <RolesTableRow user={user} schemas={schemas} />
 						})}
-					</TableRow>
-				</TableHead>
-				<TableBody>
-					{users.map((user: UserData) => {
-						return <RolesTableRow user={user} schemas={schemas} />
-					})}
-				</TableBody>
-			</Table>
-		</TableContainer>
+					</TableBody>
+				</Table>
+			</TableContainer>
+		</Box>
 	</Box>
 }
 
@@ -51,12 +52,18 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({ user, schemas, ...props }
 		setDefaultRole(event.target.value as Role)
 	}
 
-	function handleRoleChange(event: SelectChangeEvent, schema: string) {
+	function handleRoleChange(event: SelectChangeEvent<unknown>, schema: string) {
 		setSchemaRoles({ ...schemaRoles, [schema]: event.target.value as Role })
+		const primKeys = ['user', 'schema'];
+		const newRow = {user: user.email, schema, role: event.target.value as Role}
+		const upsertRoleDataAcc = vmd.getUpsertRowDataAccessor('meta', 'role_per_schema', primKeys, {}, newRow );
+		upsertRoleDataAcc.put()
+		.then(() => console.log("Schema role updated successfully."))
+		.catch(() => console.log("Error while updating the schema role"));
 	}
 
 	return <TableRow {...props}>
-		<TableCell >{user.email}</TableCell>
+		<TableCell className="sticky-column-left" sx={{ borderRight: "thin solid #e0e0e0" }}>{user.email}</TableCell>
 		<TableCell >
 			<FormControl fullWidth>
 				<Select
@@ -64,7 +71,7 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({ user, schemas, ...props }
 					value={defaultRole}
 					onChange={(event) => handleDefaultRoleChange(event)}
 					variant="outlined"
-					
+					size="small"
 
 				>
 					<MenuItem value={Role.USER}>User</MenuItem>
@@ -78,10 +85,10 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({ user, schemas, ...props }
 				<FormControl fullWidth>
 					<Select
 						name="role"
-						value={schemaRoles[schema]}
 						onChange={(event) => handleRoleChange(event, schema)}
 						variant="outlined"
-						
+						size="small"
+						disabled={defaultRole === Role.ADMIN}
 					>
 						<MenuItem value={Role.USER}>User</MenuItem>
 						<MenuItem value={Role.CONFIG}>Configurator</MenuItem>

--- a/UInnovateApp/src/components/settingsPage/Users/RolesTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/Users/RolesTab.tsx
@@ -41,11 +41,16 @@ interface RolesTableRowProps extends Omit<TableRowProps, 'children'> {
 }
 
 interface SchemaRoles {
-	[key: string]: Role;
+	[key: string]: Role | '';
 }
 
 const RolesTableRow: React.FC<RolesTableRowProps> = ({ user, schemas, ...props }) => {
-	const [schemaRoles, setSchemaRoles] = useState<SchemaRoles>({})
+	const initialSchemaRoles = schemas.reduce((roles, schema) => {
+		roles[schema] = '';
+		return roles;
+	  }, {} as SchemaRoles);
+
+	const [schemaRoles, setSchemaRoles] = useState<SchemaRoles>(initialSchemaRoles)
 	const [defaultRole, setDefaultRole] = useState(user.role)
 
 	function handleDefaultRoleChange(event: SelectChangeEvent) {
@@ -85,11 +90,13 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({ user, schemas, ...props }
 				<FormControl fullWidth>
 					<Select
 						name="role"
+						value={schemaRoles[schema] || ''}
 						onChange={(event) => handleRoleChange(event, schema)}
 						variant="outlined"
 						size="small"
 						disabled={defaultRole === Role.ADMIN}
 					>
+						<MenuItem value=''/>
 						<MenuItem value={Role.USER}>User</MenuItem>
 						<MenuItem value={Role.CONFIG}>Configurator</MenuItem>
 						{/* <MenuItem value={Role.ADMIN}>Admin</MenuItem> */}

--- a/UInnovateApp/src/components/settingsPage/Users/RolesTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/Users/RolesTab.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import { Row } from "../../../virtualmodel/DataAccessor";
+import vmd, { UserData } from "../../../virtualmodel/VMD";
+import { Box, FormControl, InputLabel, MenuItem, Paper, Select, SelectChangeEvent, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TableRowProps } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../../redux/Store";
+import { Role } from "../../../redux/AuthSlice";
+
+const RolesTab: React.FC = () => {
+	const users = useSelector((state: RootState) => state.userData.users)
+	const schemas: string[] = vmd.getApplicationSchemas().map((schema) => schema.schema_name);
+	// const schemas: string[] = ["Schema1","Schema1","Schema1","Schema1","Schema1","Schema1","Schema1","Schema1","Schema1","Schema1"]
+	
+
+	return <Box paddingTop={2} alignContent={"center"}>
+		<TableContainer >
+			<Table sx={{width:"auto"}}>
+				<TableHead>
+					<TableRow>
+						<TableCell sx={{maxWidth: "15rem"}}>Users</TableCell>
+						<TableCell sx={{minWidth:"11rem", width:"11rem"}}>Default </TableCell>
+						{schemas.map((schema) => {
+							return <TableCell key={schema} sx={{minWidth:"11rem", width:"11rem"}}>{schema}</TableCell>
+						})}
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					{users.map((user: UserData) => {
+						return <RolesTableRow user={user} schemas={schemas} />
+					})}
+				</TableBody>
+			</Table>
+		</TableContainer>
+	</Box>
+}
+
+interface RolesTableRowProps extends Omit<TableRowProps, 'children'> {
+	user: UserData,
+	schemas: string[]
+}
+
+interface SchemaRoles {
+	[key: string]: Role;
+}
+
+const RolesTableRow: React.FC<RolesTableRowProps> = ({ user, schemas, ...props }) => {
+	const [schemaRoles, setSchemaRoles] = useState<SchemaRoles>({})
+	const [defaultRole, setDefaultRole] = useState(user.role)
+
+	function handleDefaultRoleChange(event: SelectChangeEvent) {
+		setDefaultRole(event.target.value as Role)
+	}
+
+	function handleRoleChange(event: SelectChangeEvent, schema: string) {
+		setSchemaRoles({ ...schemaRoles, [schema]: event.target.value as Role })
+	}
+
+	return <TableRow {...props}>
+		<TableCell >{user.email}</TableCell>
+		<TableCell >
+			<FormControl fullWidth>
+				<Select
+					name="role"
+					value={defaultRole}
+					onChange={(event) => handleDefaultRoleChange(event)}
+					variant="outlined"
+					
+
+				>
+					<MenuItem value={Role.USER}>User</MenuItem>
+					<MenuItem value={Role.CONFIG}>Configurator</MenuItem>
+					<MenuItem value={Role.ADMIN}>Admin</MenuItem>
+				</Select>
+			</FormControl>
+		</TableCell>
+		{schemas.map((schema) => {
+			return <TableCell key={schema}>
+				<FormControl fullWidth>
+					<Select
+						name="role"
+						value={schemaRoles[schema]}
+						onChange={(event) => handleRoleChange(event, schema)}
+						variant="outlined"
+						
+					>
+						<MenuItem value={Role.USER}>User</MenuItem>
+						<MenuItem value={Role.CONFIG}>Configurator</MenuItem>
+						{/* <MenuItem value={Role.ADMIN}>Admin</MenuItem> */}
+					</Select>
+				</FormControl>
+			</TableCell>
+		})}
+	</TableRow>
+}
+
+export default RolesTab;

--- a/UInnovateApp/src/components/settingsPage/Users/UserMangementTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/Users/UserMangementTab.tsx
@@ -23,11 +23,11 @@ const UserManagementTab = () => {
 	const [isModalOpen, setModalOpen] = useState(false);
 	const [users, setUsers] = useState<Row[]>([]);
 
-	const role = useSelector((state: RootState) => state.auth.role);
+	const dbRole = useSelector((state: RootState) => state.auth.dbRole);
 	const dispatch = useDispatch();
 
 	// Hides the menu for non-admin roles (except for anonymous)
-	if (!(role === Role.ADMIN || role === null)) {
+	if (!(dbRole === Role.ADMIN || dbRole === null)) {
 		return <UnauthorizedScreen />
 	}
 
@@ -81,7 +81,6 @@ const UserManagementTab = () => {
 											firstName={user["first_name"] as string}
 											lastName={user["last_name"] as string}
 											emailAddress={user["email"] as string}
-											role={user["role"] as Role}
 											active={user["is_active"] as boolean}
 											schemaAccess={user["schema_access"]} />
 									}
@@ -107,12 +106,11 @@ interface UserTableRowProps {
 	firstName?: string,
 	lastName?: string,
 	emailAddress: string,
-	role: Role,
 	active: boolean,
 	schemaAccess: string[]
 }
-const UserTableRow: React.FC<UserTableRowProps> = ({ firstName, lastName, emailAddress, role, active, schemaAccess }) => {
-	const [userData, setUserData] = useState<UserData>({first_name: firstName, last_name: lastName, email: emailAddress, role, is_active: active, schema_access: schemaAccess})
+const UserTableRow: React.FC<UserTableRowProps> = ({ firstName, lastName, emailAddress, active, schemaAccess }) => {
+	const [userData, setUserData] = useState<UserData>({first_name: firstName, last_name: lastName, email: emailAddress, is_active: active, schema_access: schemaAccess})
 	const [schemaAccessList, setSchemaAccessList] = useState(schemaAccess);
 	const schemaNames = vmd.getApplicationSchemas().map((schema) => schema.schema_name);
 	const dispatch = useDispatch();
@@ -143,7 +141,6 @@ const UserTableRow: React.FC<UserTableRowProps> = ({ firstName, lastName, emailA
 		<td>{emailAddress}</td>
 		<td>{firstName || "-"}</td>
 		<td>{lastName || "-"}</td>
-		<td>{role}</td>
 		<td>
 			<Switch defaultChecked={active} onChange={handleActiveToggle} data-testid="visibility-switch" />
 		</td>

--- a/UInnovateApp/src/components/settingsPage/Users/UserMangementTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/Users/UserMangementTab.tsx
@@ -1,20 +1,21 @@
 import { Tab, Tabs } from "react-bootstrap";
-import { Button, FormControl, Select, Switch, MenuItem, Chip, Stack } from "@mui/material"
+import { Button, Switch } from "@mui/material"
 import TableComponent from "react-bootstrap/Table";
-import "../../styles/TableComponent.css";
-import "../../styles/UserManagementTab.css";
-import vmd, { UserData } from "../../virtualmodel/VMD";
+import "../../../styles/TableComponent.css";
+import "../../../styles/UserManagementTab.css";
+import vmd, { UserData } from "../../../virtualmodel/VMD";
 import React, { useEffect, useState } from "react";
 import AddUserModal from "./AddUserModal";
-import { DataAccessor, Row } from "../../virtualmodel/DataAccessor";
+import { DataAccessor, Row } from "../../../virtualmodel/DataAccessor";
 import { useDispatch, useSelector } from "react-redux";
-import { RootState } from "../../redux/Store";
-import { Role, updateSchemaAccess } from "../../redux/AuthSlice";
-import UnauthorizedScreen from "../UnauthorizedScreen";
-import MultiSelect from "./MultiSelect";
-import  { setUserData, updateUserData } from "../../redux/UserDataSlice";
+import { RootState } from "../../../redux/Store";
+import { Role, updateSchemaAccess } from "../../../redux/AuthSlice";
+import UnauthorizedScreen from "../../UnauthorizedScreen";
+import MultiSelect from "../MultiSelect";
+import  { setUserData, updateUserData } from "../../../redux/UserDataSlice";
 
 import {isEqual} from 'lodash';
+import RolesTab from "./RolesTab";
 
 
 // Component containing the Users Management tab of the Settings page
@@ -80,7 +81,7 @@ const UserManagementTab = () => {
 											firstName={user["first_name"] as string}
 											lastName={user["last_name"] as string}
 											emailAddress={user["email"] as string}
-											role={user["role"] as string}
+											role={user["role"] as Role}
 											active={user["is_active"] as boolean}
 											schemaAccess={user["schema_access"]} />
 									}
@@ -91,8 +92,8 @@ const UserManagementTab = () => {
 						</TableComponent>
 					</div>
 				</Tab>
-				<Tab eventKey="roles" title="Roles" disabled>
-
+				<Tab eventKey="roles" title="Roles">
+					<RolesTab/>
 				</Tab>
 
 			</Tabs>
@@ -106,7 +107,7 @@ interface UserTableRowProps {
 	firstName?: string,
 	lastName?: string,
 	emailAddress: string,
-	role: string,
+	role: Role,
 	active: boolean,
 	schemaAccess: string[]
 }

--- a/UInnovateApp/src/components/settingsPage/additionalView/AdditionalViewTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/additionalView/AdditionalViewTab.tsx
@@ -2,11 +2,14 @@ import React, { useCallback, useState } from 'react'
 import AdditionalViewEditor from './AdditionalViewEditor';
 import { Col, Row, Tab } from 'react-bootstrap';
 import SchemaTableSelector from '../../Schema/SchemaTableSelector';
+import TableSelector from '../TableSelector';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../redux/Store';
 
 const AdditionalViewTab = () => {
 
     const [table,setTable] = useState<string>('');
-    const [schema,setSchema] = useState<string>('');
+    const selectedSchema = useSelector((state: RootState) => state.schema.value);
 
   return (
     <>
@@ -14,10 +17,11 @@ const AdditionalViewTab = () => {
         <Tab.Content id='AdditionalViewEditor'>
         <Row>
             <Col sm='3'>
-                <SchemaTableSelector setTable={setTable} setSchema={setSchema}/>
+                {/* <SchemaTableSelector setTable={setTable} setSchema={setSchema}/> */}
+                <TableSelector setTable={setTable}/>
             </Col>
             <Col sm='9' >
-                <AdditionalViewEditor selectedSchema={schema} selectedTable={table} setSelectedTable={setTable}/>
+                <AdditionalViewEditor selectedSchema={selectedSchema} selectedTable={table} setSelectedTable={setTable}/>
             </Col>
         </Row>
         </Tab.Content>

--- a/UInnovateApp/src/helper/RolesHelpers.ts
+++ b/UInnovateApp/src/helper/RolesHelpers.ts
@@ -1,0 +1,38 @@
+import vmd from "../virtualmodel/VMD";
+import { Role } from "../redux/AuthSlice";
+import { SchemaRoles } from "../components/settingsPage/Users/RolesTab";
+
+/**
+ * Function that obtains the schema roles for a given user
+ * @returns SchemaRoles
+ */
+export async function getSchemaRoles(user: string): Promise<SchemaRoles> {
+	const rolePerSchemaDA = vmd.getRowDataAccessor('meta', 'role_per_schema', 'user', user);
+	const rolePerSchemaResponse = await rolePerSchemaDA.fetchRows();
+	if (rolePerSchemaResponse) {
+		const reducedRolePerSchema = rolePerSchemaResponse.reduce((obj, { schema, role }) => {
+			obj[schema] = role;
+			return obj;
+		}, {});
+		return reducedRolePerSchema;
+	} else {
+		console.log('Failed to obtain the schema roles of user ' + user);
+		return {};
+	}
+}
+/**
+ * Function that obtains the default role for a given user
+ * @returns Role
+ */
+
+export async function getDefaultRole(user: string): Promise<Role | null> {
+	const defaultRoleDA = vmd.getViewRowDataAccessor('meta', 'user_info', ['email'], [user]);
+	const response = await defaultRoleDA.fetchRows();
+	if (response) {
+		const defaultRole = response[0]['role'];
+		return defaultRole as Role;
+	} else {
+		console.log('Failed to obtain the default role of user ' + user);
+		return null;
+	}
+}

--- a/UInnovateApp/src/pages/Settings.tsx
+++ b/UInnovateApp/src/pages/Settings.tsx
@@ -33,9 +33,10 @@ export function Settings() {
 				// Ensures that on LOGIN_BYPASS without being logged in, all the schemas show
 				if ((LOGIN_BYPASS && user === null) // Include if LOGIN_BYPASS enabled with no user logged in
 					|| (schema_access.includes(schema_name)) // Schema must be in schema_access list
-					&& (schemaRoles[schema_name] === Role.CONFIG // User must have role configurator for schema in schema roles
-						|| (!schemaRoles[schema_name] && defaultRole === Role.CONFIG) // OR User doesn't have any role set for schema and its default role is configurator
-					)) {
+					&& (dbRole === Role.ADMIN // AND User must be an admin
+						||(schemaRoles[schema_name] === Role.CONFIG // OR User must have role configurator for schema in schema roles
+							|| (!schemaRoles[schema_name] && defaultRole === Role.CONFIG) // OR User doesn't have any role set for schema and its default role is configurator
+						))) {
 					return schema_name;
 				}
 			})),

--- a/UInnovateApp/src/pages/Settings.tsx
+++ b/UInnovateApp/src/pages/Settings.tsx
@@ -13,21 +13,50 @@ import UserManagementTab from "../components/settingsPage/Users/UserMangementTab
 import ButtonConfigurationSaver from "../components/settingsPage/ButtonConfigurationSaver";
 import InternationalizationTab from "../components/settingsPage/InternationalizationTab";
 import UnauthorizedScreen from "../components/UnauthorizedScreen";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../redux/Store";
 import { LOGIN_BYPASS, Role } from "../redux/AuthSlice";
 import { useNavigate, useParams } from "react-router-dom";
 import AdditionalViewTab from "../components/settingsPage/additionalView/AdditionalViewTab";
+import { Box, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent } from "@mui/material";
+import vmd from "../virtualmodel/VMD";
+import { useEffect, useState } from "react";
+import { updateSelectedSchema } from "../redux/SchemaSlice";
 
 export function Settings() {
-	const role = useSelector((state: RootState) => state.auth.role);
+	const dispatch = useDispatch();
+	const { user, schema_access, role } = useSelector((state: RootState) => state.auth);
+	const schemas = [
+		...new Set(vmd.getApplicationSchemas()
+			.map((schema) => schema.schema_name)
+			.filter((schema_name) => {
+				// Ensures that on LOGIN_BYPASS without being logged in, all the schemas show
+				if ((LOGIN_BYPASS && user === null) || schema_access.includes(schema_name)) {
+					return schema_name;
+				}
+			})),
+	];
+	// Prevents error when schema_access has a length of 0
+	const initialSelectedSchema = schemas.length === 0 ? "" : schemas[0]
+	const [selectedSchema, setSelectedSchema] = useState(initialSelectedSchema);
+
+
+	useEffect(() => {
+		dispatch(updateSelectedSchema(selectedSchema));
+	}, [selectedSchema])
+
+	const handleSchemaChange = (event: SelectChangeEvent) => {
+		setSelectedSchema(event.target.value);
+	  };
+
+
 	const navigate = useNavigate();
-	const {option} = useParams();
+	const { option } = useParams();
 
 
 	const handleNavClick = (
-		val: string	) => {
-		
+		val: string) => {
+
 		navigate(`/settings/${val.toLowerCase()}`);
 	};
 
@@ -40,7 +69,25 @@ export function Settings() {
 			) : (
 				<div className='page-container'>
 					<div className='save-config-container'>
-						<h1 className='title'>Settings</h1>
+						<Box display="flex" gap={"1rem"} alignItems={"center"}>
+							<h1 className='title'>Settings</h1>
+							<FormControl fullWidth disabled={schemas.length === 0}>
+								<InputLabel id="schema-label">Schema</InputLabel>
+								<Select
+									labelId="schema-label"
+									name="schema"
+									value={selectedSchema}
+									onChange={(event) => handleSchemaChange(event)}
+									variant="outlined"
+									label="Schema"
+									size="small"
+								>
+									{schemas.map((schema) => {
+										return <MenuItem key={schema} value={schema}>{schema}</MenuItem>
+									})};
+								</Select>
+							</FormControl>
+						</Box>
 						<ButtonConfigurationSaver />
 					</div>
 					<Tab.Container activeKey={option} id='left-tabs-example' >
@@ -48,17 +95,17 @@ export function Settings() {
 							<Col sm={3}>
 								<Nav variant='pills' className='flex-column' >
 									<Nav.Item>
-										<Nav.Link eventKey='general'  onClick={() => handleNavClick('general')} >General</Nav.Link>
+										<Nav.Link eventKey='general' onClick={() => handleNavClick('general')} >General</Nav.Link>
 									</Nav.Item>
 									<Nav.Item>
 										<Nav.Link eventKey='display' onClick={() => handleNavClick('display')}>Display</Nav.Link>
 									</Nav.Item>
 									<Nav.Item>
-										<Nav.Link eventKey='schedule'onClick={() => handleNavClick('schedule')}>
+										<Nav.Link eventKey='schedule' onClick={() => handleNavClick('schedule')}>
 											Scheduled Activities
 										</Nav.Link>
-										<Nav.Link eventKey='scripting'onClick={() => handleNavClick('scripting')}>Scripting</Nav.Link>
-										
+										<Nav.Link eventKey='scripting' onClick={() => handleNavClick('scripting')}>Scripting</Nav.Link>
+
 										<Nav.Link eventKey='envvar' onClick={() => handleNavClick('envvar')}>Environment Variables</Nav.Link>
 									</Nav.Item>
 									{(role === Role.ADMIN || LOGIN_BYPASS && role === null) && (
@@ -115,3 +162,4 @@ export function Settings() {
 		</>
 	);
 }
+

--- a/UInnovateApp/src/pages/Settings.tsx
+++ b/UInnovateApp/src/pages/Settings.tsx
@@ -61,7 +61,7 @@ export function Settings() {
 										
 										<Nav.Link eventKey='envvar' onClick={() => handleNavClick('envvar')}>Environment Variables</Nav.Link>
 									</Nav.Item>
-									{(role === Role.ADMIN || LOGIN_BYPASS) && (
+									{(role === Role.ADMIN || LOGIN_BYPASS && role === null) && (
 										<Nav.Item>
 											<Nav.Link eventKey='users' onClick={() => handleNavClick('users')} >Users</Nav.Link>
 										</Nav.Item>
@@ -95,7 +95,7 @@ export function Settings() {
 									<Tab.Pane eventKey='envvar'>
 										<EnvVarCreator />
 									</Tab.Pane>
-									{(role === Role.ADMIN || role === null) && (
+									{(role === Role.ADMIN || LOGIN_BYPASS && role === null) && (
 										<Tab.Pane eventKey='users'>
 											<UserManagementTab />
 										</Tab.Pane>

--- a/UInnovateApp/src/pages/Settings.tsx
+++ b/UInnovateApp/src/pages/Settings.tsx
@@ -9,7 +9,7 @@ import Nav from "react-bootstrap/Nav";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import "../styles/settings.css";
-import UserManagementTab from "../components/settingsPage/UserMangementTab";
+import UserManagementTab from "../components/settingsPage/Users/UserMangementTab";
 import ButtonConfigurationSaver from "../components/settingsPage/ButtonConfigurationSaver";
 import InternationalizationTab from "../components/settingsPage/InternationalizationTab";
 import UnauthorizedScreen from "../components/UnauthorizedScreen";

--- a/UInnovateApp/src/redux/AuthSlice.tsx
+++ b/UInnovateApp/src/redux/AuthSlice.tsx
@@ -10,7 +10,7 @@ import { SchemaRoles } from "../components/settingsPage/Users/RolesTab";
 export interface AuthState {
 	user: string | null;
 	token: string | null;
-	dbRole: string | null; // Default role
+	dbRole: string | null; // Database role, i.e. the role giving you db permissiosn
 	defaultRole: string | null; // Default role
 	schema_access: string[];
 	schemaRoles: SchemaRoles;

--- a/UInnovateApp/src/redux/AuthSlice.tsx
+++ b/UInnovateApp/src/redux/AuthSlice.tsx
@@ -5,14 +5,18 @@ import vmd from "../virtualmodel/VMD";
 
 export const LOGIN_BYPASS = import.meta.env.VITE_LOGIN_BYPASS === "true";
 
+import { SchemaRoles } from "../components/settingsPage/Users/RolesTab";
+
 export interface AuthState {
 	user: string | null;
 	token: string | null;
-	role: string | null;
+	dbRole: string | null; // Default role
+	defaultRole: string | null; // Default role
 	schema_access: string[];
+	schemaRoles: SchemaRoles;
 }
 
-interface DecodedToken {
+export interface DecodedToken {
 	role: string;
 	email: string;
 	schema_access: string[];
@@ -27,7 +31,7 @@ export enum Role {
 
 const authSlice = createSlice({
 	name: "auth",
-	initialState: { user: null, token: null, role: null, schema_access: [] } as AuthState,
+	initialState: { user: null, token: null, dbRole: null, defaultRole:null, schema_access: [], schemaRoles:{} } as AuthState,
 	reducers: {
 		logIn: (state: AuthState, action: PayloadAction<string>) => {
 			const token = action.payload;
@@ -35,18 +39,20 @@ const authSlice = createSlice({
 
 			// Obtains the role & email from the "role" and "email" claims of the JWT token
 			const decodedToken = jwtDecode(token) as DecodedToken;
-			state.role = decodedToken.role;
+			state.dbRole = decodedToken.role;
 			state.user = decodedToken.email;
 			state.schema_access = decodedToken.schema_access || [];
-			console.log(state.schema_access)
+			// console.log(state.schema_access)
 
 			axiosCustom.defaults.headers.common["Authorization"] = `bearer ${token}`;
 		},
 		logOut: (state: AuthState, action: PayloadAction) => {
 			state.user = null;
 			state.token = null;
-			state.role = null;
+			state.dbRole = null;
+			state.defaultRole = null;
 			state.schema_access = [];
+			state.schemaRoles = {};
 
 			axiosCustom.defaults.headers.common["Authorization"] = undefined;
 
@@ -56,10 +62,20 @@ const authSlice = createSlice({
 		updateSchemaAccess: (state: AuthState, action: PayloadAction<string[]>) => {
 			const newSchemaAccess = action.payload;
 			state.schema_access = newSchemaAccess;
-		}
+		},
+		updateSchemaRoles: (state: AuthState, action: PayloadAction<SchemaRoles>) => {
+			const newSchemaRoles = action.payload;
+			state.schemaRoles= newSchemaRoles;
+			// console.log(newSchemaRoles);
+		},
+		updateDefaultRole: (state: AuthState, action: PayloadAction<Role|null>) => {
+			const defaultRole = action.payload;
+			state.defaultRole= defaultRole;
+			console.log(defaultRole);
+		},
 	},
 });
 
-export const { logIn, logOut, updateSchemaAccess } = authSlice.actions;
+export const { logIn, logOut, updateSchemaAccess, updateSchemaRoles, updateDefaultRole } = authSlice.actions;
 
 export default authSlice.reducer;

--- a/UInnovateApp/src/styles/TableComponent.css
+++ b/UInnovateApp/src/styles/TableComponent.css
@@ -77,3 +77,10 @@ input {
   margin-top: 1em;
   margin-bottom:2em
 }
+
+.sticky-column-left{
+  position: sticky;
+  left:0;
+  background-color: white;
+  z-index: 2;
+}

--- a/UInnovateApp/src/tests/components/settingsPage/UserManagementTab.test.tsx
+++ b/UInnovateApp/src/tests/components/settingsPage/UserManagementTab.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import UserManagementTab from "../../../components/settingsPage/UserMangementTab"
+import UserManagementTab from "../../../components/settingsPage/Users/UserMangementTab"
 import { describe, expect } from "vitest";
 import { Middleware, Store } from "@reduxjs/toolkit";
 import configureStore from "redux-mock-store";

--- a/UInnovateApp/src/tests/components/settingsPage/UserManagementTab.test.tsx
+++ b/UInnovateApp/src/tests/components/settingsPage/UserManagementTab.test.tsx
@@ -7,12 +7,18 @@ import { Role } from "../../../redux/AuthSlice";
 import { ConfigProvider } from "../../../contexts/ConfigContext";
 import { Provider } from "react-redux";
 import { ErrMsg } from "../../../enums/ErrMsg";
+import { MemoryRouter } from "react-router-dom";
 
 describe("UserManagementTab component", () => {
 	const initialState = {
 		schema: { schema_name: "application" },
 		script_table: { table_name: "script_mock" },
-		auth: { role: Role.ADMIN, user: "admin", token: "token" } 
+		auth: { dbRole: Role.ADMIN, user: "admin", token: "token" },
+		userData: {
+			users: [{ email: "mockuser123@test.com", role: "user", schema_access: ["mock schema name"], schemaRoles: {} },
+			{ email: "mockAdmin@test.com", role: "administrator", schema_access: ["mock schema name"], schemaRoles: {} },
+			{ email: "mockConfigurator@test.com", role: "configurator", schema_access: ["mock schema name"], schemaRoles: {} }]
+		}
 	};
 	const middlewares: Middleware[] = [];
 	const mockStore = configureStore(middlewares);
@@ -22,19 +28,23 @@ describe("UserManagementTab component", () => {
 	it("renders the component", () => {
 		store = mockStore(initialState);
 		render(
-			<ConfigProvider>
-				<Provider store={store}>
-					<UserManagementTab />
-				</Provider>
-			</ConfigProvider>
+			<MemoryRouter>
+				<ConfigProvider>
+					<Provider store={store}>
+						<UserManagementTab />
+					</Provider>
+				</ConfigProvider>
+			</MemoryRouter>
 		);
 	}),
 		it("displays the add user modal when the add user button is clicked", async () => {
-			const { getByText } = render(<ConfigProvider>
-				<Provider store={store}>
-					<UserManagementTab />
-				</Provider>
-			</ConfigProvider>);
+			const { getByText } = render(<MemoryRouter>
+				<ConfigProvider>
+					<Provider store={store}>
+						<UserManagementTab />
+					</Provider>
+				</ConfigProvider>
+			</MemoryRouter>);
 			const button = getByText("Add User");
 			fireEvent.click(button);
 
@@ -44,11 +54,13 @@ describe("UserManagementTab component", () => {
 			});
 		}),
 		it("closes the add user modal when the cancel button is clicked", async () => {
-			render(<ConfigProvider>
-				<Provider store={store}>
-					<UserManagementTab />
-				</Provider>
-			</ConfigProvider>);
+			render(<MemoryRouter>
+				<ConfigProvider>
+					<Provider store={store}>
+						<UserManagementTab />
+					</Provider>
+				</ConfigProvider>
+			</MemoryRouter>);
 			const button = screen.getByText("Add User");
 			fireEvent.click(button);
 
@@ -67,11 +79,13 @@ describe("UserManagementTab component", () => {
 			});
 		})
 	it("sends the request upon clicking the add user button", async () => {
-		render(<ConfigProvider>
-			<Provider store={store}>
-				<UserManagementTab />
-			</Provider>
-		</ConfigProvider>);
+		render(<MemoryRouter>
+			<ConfigProvider>
+				<Provider store={store}>
+					<UserManagementTab />
+				</Provider>
+			</ConfigProvider>
+		</MemoryRouter>);
 		const button = screen.getByText("Add User");
 		fireEvent.click(button);
 
@@ -94,11 +108,13 @@ describe("UserManagementTab component", () => {
 		it("Displays an error message if the email address is not valid", async () => {
 			store = mockStore(initialState);
 			render(
-				<ConfigProvider>
-					<Provider store={store}>
-						<UserManagementTab />
-					</Provider>
-				</ConfigProvider>
+				<MemoryRouter>
+					<ConfigProvider>
+						<Provider store={store}>
+							<UserManagementTab />
+						</Provider>
+					</ConfigProvider>
+				</MemoryRouter>
 			);
 			const button = screen.getByText("Add User");
 			fireEvent.click(button);

--- a/UInnovateApp/src/tests/settings.test.tsx
+++ b/UInnovateApp/src/tests/settings.test.tsx
@@ -15,7 +15,12 @@ describe("Settings.tsx", () => {
   const initialState = {
     schema: { schema_name: "application" },
     script_table: { table_name: "script_mock" },
-    auth: { role: Role.ADMIN, user: "admin", token: "token", schema_access: ['mock schema name'] }
+    auth: { dbRole: Role.ADMIN, schemaRoles: {}, user: "admin", token: "token", schema_access: ['mock schema name'] },
+    userData: {
+      users: [{ email: "mockuser123@test.com", role: "user", schema_access: ["mock schema name"], schemaRoles: {} },
+      { email: "mockAdmin@test.com", role: "administrator", schema_access: ["mock schema name"], schemaRoles: {} },
+      { email: "mockConfigurator@test.com", role: "configurator", schema_access: ["mock schema name"], schemaRoles: {} }]
+    }
   };
   const middlewares: Middleware[] = [];
   const mockStore = configureStore(middlewares);

--- a/UInnovateApp/src/virtualmodel/DataAccessor.tsx
+++ b/UInnovateApp/src/virtualmodel/DataAccessor.tsx
@@ -108,6 +108,23 @@ export class DataAccessor {
     }
   }
 
+
+  /**Method to upsert a SINGLE ROW in a table
+   * @returns AxiosResponse
+   */
+  async put(){
+    try {
+      const response = await axiosCustom.put(this.data_url, this.values, {
+        params: this.params,
+        headers: this.headers,
+      });
+
+      return response;
+    } catch (error) {
+      console.error("Could not update or insert row:", error);
+    }
+  }
+
   // Method to delete a row from a table
   // return type: AxiosResponse
   async deleteRow() {

--- a/UInnovateApp/src/virtualmodel/DataAccessor.tsx
+++ b/UInnovateApp/src/virtualmodel/DataAccessor.tsx
@@ -122,6 +122,7 @@ export class DataAccessor {
       return response;
     } catch (error) {
       console.error("Could not update or insert row:", error);
+      throw error;
     }
   }
 
@@ -131,6 +132,7 @@ export class DataAccessor {
     try {
       const response = await axiosCustom.delete(this.data_url, {
         headers: this.headers,
+        params: this.params
       });
 
       return response;

--- a/UInnovateApp/src/virtualmodel/DataAccessor.tsx
+++ b/UInnovateApp/src/virtualmodel/DataAccessor.tsx
@@ -29,6 +29,7 @@ export class DataAccessor {
       const response = await axiosCustom.get(this.data_url, {
         signal: signal,
         headers: this.headers,
+        params: this.params
       });
 
       response.data.forEach((row: Row) => {

--- a/UInnovateApp/src/virtualmodel/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/VMD.tsx
@@ -539,6 +539,29 @@ class VirtualModelDefinition {
     }
   }
 
+// Method to return a data accessor to get rows from a view of a given schema filtered by the search_key(s)
+  // return type: DataAccessor
+  getViewRowDataAccessor(
+    schema_name: string,
+    view_name: string,
+    search_key: string[],
+    search_key_value: string[]
+  ): DataAccessor {
+    const schema = this.getSchema(schema_name);
+    const view = schema?.getView(view_name);
+    if (schema && view) {
+      const searchKeyAsParams = search_key.reduce<Record<string, string>>((obj, key, i) => {
+        obj[key] = `eq.${search_key_value[i]}`;
+        return obj;
+      }, {})
+      return new DataAccessor(view.url, {
+        "Accept-Profile": schema.schema_name,
+      }, searchKeyAsParams);
+    } else {
+      throw new Error("Schema or view does not exist");
+    }
+  }
+
   // Method to return a data accessor to get all the rows from a view of a given schema
   // return type: DataAccessor
   getViewRowsDataAccessor(
@@ -923,7 +946,7 @@ export interface UserData {
   email: string;
   first_name?: string;
   last_name?: string;
-  role?: Role;
+  role?: Role; // Default role
   is_active?: boolean;
   schema_access?: string[];
 }

--- a/UInnovateApp/src/virtualmodel/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/VMD.tsx
@@ -1,4 +1,5 @@
 import axiosCustom from "../api/AxiosCustom";
+import { Role } from "../redux/AuthSlice";
 import { DataAccessor, Row } from "./DataAccessor";
 import { FunctionAccessor } from "./FunctionAccessor";
 
@@ -879,7 +880,7 @@ export interface UserData {
   email: string;
   first_name?: string;
   last_name?: string;
-  role?: string;
+  role?: Role;
   is_active?: boolean;
   schema_access?: string[];
 }

--- a/database/auth.sql
+++ b/database/auth.sql
@@ -439,13 +439,13 @@ END $$ LANGUAGE plpgsql;
 
 GRANT EXECUTE ON FUNCTION meta.logout() TO "user";
 GRANT SELECT ON TABLE meta.role_per_schema TO "user";
+GRANT SELECT ON TABLE meta.user_info TO "user";
 -- Configurator role
 
 
 -- Administrator role
 
 GRANT EXECUTE ON FUNCTION meta.create_user(text, name) TO administrator;
-GRANT SELECT ON TABLE meta.user_info TO administrator;
 GRANT ALL ON TABLE meta.role_per_schema TO administrator;
 GRANT EXECUTE ON FUNCTION meta.update_default_role(text, name) TO administrator;
 


### PR DESCRIPTION
# ⚠️ RUN THE REFRESH SCRIPT!!! ⚠️ 
## Major Changes
### Major Roles Refactor
Previously, users would only have a single role (user, configurator or administrator) that would apply on the entire platform (i.e. all application schemas. 

Now, users have 3 kinds of separate roles:
1. **Default Role**: Initially, this is the role set by the administrator when creating the user. It acts as the default role for application schemas which do not have a **schema role** specified for a particular user. It can be modified through the Roles tab of the User Management menu.
2. **Schema Role**: Now, a user can have schema-specific roles for added flexibility within the user management. I.e. for each application schema present in a user's schema access list, they can have a different role than their **default role**. Initially, no schema roles are specified for a user. They can be configured from the Roles tab of the User Management menu.
> ⚠️ Please note that users with **administrator** default role cannot have schema-specific roles because the administrator role is considered as a **Global** role.
3. **Database Role**: This role is an implicit one, never seen nor manually modified by any user, only materialized by the database. Its purpose is to provide proper database permissions based on both the **default role** and the **schema roles** of a user. It is used mainly within the jwt access token used to make API calls to the PostgREST API. It is defined as being the highest-ranked role amongst a user's **default role** and **schema roles**.

e.g. A user with:
- Default role: user
- Schema roles:
    - schema1 = configurator
    - schema2 = user

will have a database role of **configurator**, since it has the configurator role for schema1.

### Role Tab
![image](https://github.com/WillTrem/UInnovate/assets/64431699/2ba710fd-1bcf-418d-95a2-172cfbc2e740)
This is where any role (either default or schema-specific) can be modified.

### Global Settings Schema Selector
Due to the roles refactor, having a single schema selector for all the settings tabs at once made implementation way more straightforward. 
![image](https://github.com/WillTrem/UInnovate/assets/64431699/0b72799d-c3fe-4af9-8449-353e01e21963)

