### PR TITLE
fixed a small bug causing the additional view to remain when schema is changed

### DIFF
--- a/UInnovateApp/src/pages/ObjectMenu.tsx
+++ b/UInnovateApp/src/pages/ObjectMenu.tsx
@@ -35,6 +35,7 @@ export function ObjectMenu() {
   
   useEffect(() => {
     dispatch(updateSelectedSchema(schema ?? ""));
+    setActiveTable(null);
   }, [schema]);
   const {user, schema_access} = useSelector((state: RootState) => state.auth);
 


### PR DESCRIPTION
fixed the bug. The navigation will hide whenever the schema is changed. The user will have to re-select a table to view the additional view navbar

![adddition_views_nav_bug](https://github.com/WillTrem/UInnovate/assets/10947924/42fc2b5d-ba08-4963-aa7e-547bf9bb60db)
