### PR TITLE
[FIX] bug 279 + additional tasks

### DIFF
--- a/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
@@ -6,7 +6,6 @@ import { Button, SelectChangeEvent } from "@mui/material";
 import TableComponent from "react-bootstrap/Table";
 import { IoLockClosed } from "react-icons/io5";
 import { IoMdAddCircle } from "react-icons/io"; 
-import { PiNotePencilBold } from "react-icons/pi";
 import { MdDelete } from "react-icons/md";
 import { FormControl, InputLabel, Select, MenuItem } from "@mui/material";
 import "../../styles/InternationalizationTab.css";
@@ -372,8 +371,10 @@ interface TranslationTableRowProps {
 }
 
 const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslations, keyCode, value, is_default, onEdit }) => {
+    const [showModalDeleteLabel, setshowModalDeleteLabel] = useState<boolean>(false);
     const [isEditing, setIsEditing] = useState(false);
-    const [editedValue, setEditedValue] = useState(value || "");
+    const [editedValue, setEditedValue] = useState(keyCode);
+
 
     const handleDoubleClick = () => {
         if (!is_default) {
@@ -383,6 +384,7 @@ const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslatio
 
     const handleBlur = () => {
         if (!is_default) {
+            console.log(is_default)
             setIsEditing(false);
             saveChanges(); 
         }
@@ -441,20 +443,30 @@ const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslatio
         } catch (error) {
             console.error('Error deleting row:', error);
         }
+
+        setshowModalDeleteLabel(false);
     };
 
     const saveChanges = async () => {
         try {
-            if (value !== editedValue) {
+            if (keyCode !== editedValue) {
                 // Console log the changes
-                console.log(`Changes detected: ${value} -> ${editedValue}`);
-                onEdit(keyCode || "", editedValue);
+                console.log(`Changes detected: ${keyCode} -> ${editedValue}`);
+                onEdit(keyCode || "", editedValue || "");
             }
 
         } catch (error) {
             console.error('Error saving changes:', error);
         }
 
+    };
+
+    const showModalDelete = () => {
+        setshowModalDeleteLabel(true);
+    };
+
+    const handleClose = () => {
+        setshowModalDeleteLabel(false);
     };
 
     useEffect(() => {
@@ -482,15 +494,38 @@ const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslatio
                 />
                 {is_default ? <IoLockClosed className="icon-lock" /> : (
                     <>
-                        <PiNotePencilBold
-                            style={{ marginLeft: 5, cursor: 'pointer' }}
-                            onClick={handleDoubleClick}
-                        /> {/* Edit icon */}
-                        <MdDelete onClick={() => handleDelete(keyCode || '')}  style={{ marginLeft: 5, cursor: 'pointer' }} /> {/* Delete icon */}
+                        <MdDelete onClick={showModalDelete} className="icon-delete" /> 
                     </>
-                )}
+                )} 
+                <Modal show={showModalDeleteLabel} onHide={handleClose}>
+                    <Modal.Header>
+                        <Modal.Title>Delete Label</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <p>Are you sure you want to delete the label <b>{keyCode}</b>?</p>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <div>
+                            <Button
+                                onClick={() => handleDelete(keyCode || '')}
+                                style={buttonStyle}
+                                variant="contained"
+                            >
+                                Delete
+                            </Button>
+                            <Button
+                                onClick={handleClose}
+                                style={buttonStyle}
+                                variant="contained"
+                            >
+                                Cancel
+                            </Button>
+                        </div>
+                    </Modal.Footer>
+                </Modal>
             </td>
-        </tr>
+        </tr> 
+    
     );
 };
 

--- a/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
@@ -384,7 +384,6 @@ const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslatio
 
     const handleBlur = () => {
         if (!is_default) {
-            console.log(is_default)
             setIsEditing(false);
             saveChanges(); 
         }
@@ -450,8 +449,6 @@ const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslatio
     const saveChanges = async () => {
         try {
             if (keyCode !== editedValue) {
-                // Console log the changes
-                console.log(`Changes detected: ${keyCode} -> ${editedValue}`);
                 onEdit(keyCode || "", editedValue || "");
             }
 

--- a/UInnovateApp/src/styles/InternationalizationTab.css
+++ b/UInnovateApp/src/styles/InternationalizationTab.css
@@ -14,3 +14,12 @@ td.container-labels {
 .icon-lock {
     color: #C0C0C0;
 }
+
+.icon-delete {
+    color: #C0C0C0;
+    cursor: pointer;
+}
+
+.icon-delete:hover {
+    color: #FF0000;
+}


### PR DESCRIPTION
## Main Bug
Main bug has been fixed, hence when you try to edit a label, on edit mode the cell doesn't delete the previous content of the key.

### How it would behave before.
As you can see on edit mode, the previous key "test" is deleted and you need to write the entry from the start.
<img width="476" alt="Screenshot 2024-03-19 at 10 57 16 AM" src="https://github.com/WillTrem/UInnovate/assets/74876532/f9123f8c-4d7e-4a89-ad5f-5b236098efe4">

### How it behaves after the bug fix. 
You can see that the label "chao" is still there and you can edit it by adding more letters onto the previous label or deleting it.
<img width="626" alt="Screenshot 2024-03-19 at 10 58 04 AM" src="https://github.com/WillTrem/UInnovate/assets/74876532/6ebd2a65-7e18-4732-ba8b-db24a989fe46">


## Additional tasks include:
- Adding a confirmation modal for a deletion of label
<img width="549" alt="Screenshot 2024-03-19 at 11 00 44 AM" src="https://github.com/WillTrem/UInnovate/assets/74876532/5a60794f-0230-4ec5-87d9-fa7903fbf001">

- Adding a hover on the delete icon to have a visible red colour
- removing the edit icon.

<img width="644" alt="Screenshot 2024-03-19 at 11 01 24 AM" src="https://github.com/WillTrem/UInnovate/assets/74876532/debd5f04-7153-4fa9-8f3f-82f69bbca02f">
