### PR TITLE
231 lookup table

### DIFF
--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -486,7 +486,7 @@ const TableListView: React.FC<TableListViewProps> = ({
     }));
   };
 
-  const {user: loggedInUser }: AuthState = useSelector((state: RootState) => state.auth);
+  const { user: loggedInUser }: AuthState = useSelector((state: RootState) => state.auth);
 
   const handleFormSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -507,7 +507,7 @@ const TableListView: React.FC<TableListViewProps> = ({
     );
 
     const storedPrimaryKeyValue = currentRow.row ? currentRow.row[currentPrimaryKey as string] : null;
-    
+
 
     const data_accessor: DataAccessor = vmd.getUpdateRowDataAccessorView(
       schema.schema_name,
@@ -599,9 +599,9 @@ const TableListView: React.FC<TableListViewProps> = ({
       return null;
     }
 
-   
 
-    
+
+
     return showFiles && currentFileGroup ? (
       <div title="Dropzone">
         <Dropzone
@@ -635,7 +635,7 @@ const TableListView: React.FC<TableListViewProps> = ({
           element.property == ConfigProperty.COLUMN_DISPLAY_TYPE
       );
 
-     
+
       if (
         !columnDisplayType ||
         columnDisplayType.value == "text" ||
@@ -830,8 +830,7 @@ const TableListView: React.FC<TableListViewProps> = ({
       detailtype = "standalone";
     }
     navigate(
-      `/${schema?.schema_name.toLowerCase()}/${table.table_name.toLowerCase()}/${
-        row.row[table.table_name + "_id"]
+      `/${schema?.schema_name.toLowerCase()}/${table.table_name.toLowerCase()}/${row.row[table.table_name + "_id"]
       }?details=${detailtype}`
     );
     setOpenPanel(true);
@@ -1082,16 +1081,16 @@ const TableListView: React.FC<TableListViewProps> = ({
                         ? cell.toString()
                         : columns[idx].references_table === "filegroup"
                           ? (
-                              fileGroupsView?.find(
-                                (fileGroup) => fileGroup.id === cell
-                              )?.count || 0
-                            ).toString() + " file(s)"
+                            fileGroupsView?.find(
+                              (fileGroup) => fileGroup.id === cell
+                            )?.count || 0
+                          ).toString() + " file(s)"
                           : (cell as React.ReactNode)}
                     </Box>
                   </TableCell>
                 ))}
                 <TableCell>
-                 <DeleteRowButton getRows={getRows} table={table} row={row} />
+                  <DeleteRowButton getRows={getRows} table={table} row={row} />
                 </TableCell>
 
               </TableRow>
@@ -1218,8 +1217,7 @@ const TableListView: React.FC<TableListViewProps> = ({
               <div></div>
             ) : showTable ? (
               <div style={{ paddingBottom: "2em" }}>
-                <LookUpTableDetails table={table} currentRow={currentRow.row} />
-              </div>
+                {currentRow.row && <LookUpTableDetails table={table} currentRow={currentRow.row} />}              </div>
             ) : (
               <Button
                 variant="contained"
@@ -1227,7 +1225,7 @@ const TableListView: React.FC<TableListViewProps> = ({
                   marginTop: 20,
                   backgroundColor: "#403eb5",
                   width: "fit-content",
-                  marginLeft: 10,
+                  marginLeft: '12px',
                 }}
                 onClick={() => setShowTable(true)}
               >

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -487,6 +487,7 @@ const TableListView: React.FC<TableListViewProps> = ({
   };
 
   const {user: loggedInUser }: AuthState = useSelector((state: RootState) => state.auth);
+
   const handleFormSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -505,18 +506,17 @@ const TableListView: React.FC<TableListViewProps> = ({
       table.table_name
     );
 
-    const storedPrimaryKeyValue = localStorage.getItem(
-      "currentPrimaryKeyValue"
-    );
+    const storedPrimaryKeyValue = currentRow.row ? currentRow.row[currentPrimaryKey as string] : null;
+    
 
     const data_accessor: DataAccessor = vmd.getUpdateRowDataAccessorView(
       schema.schema_name,
       table.table_name,
       inputValues,
       currentPrimaryKey as string,
-      storedPrimaryKeyValue as string
+      storedPrimaryKeyValue as unknown as string
     );
-    data_accessor.updateRow().then((res) => {
+    data_accessor.updateRow().then(() => {
       getRows();
     });
     setInputValues({});
@@ -599,20 +599,9 @@ const TableListView: React.FC<TableListViewProps> = ({
       return null;
     }
 
-    if (column.is_editable == false) {
-      localStorage.setItem(
-        "currentPrimaryKeyValue",
-        currentRow.row[column.column_name]
-      );
-    }
+   
 
-    if (column.references_table != null) {
-      const string = column.column_name + "L";
-      localStorage.setItem(
-        string,
-        currentRow.row[column.column_name] as string
-      );
-    }
+    
     return showFiles && currentFileGroup ? (
       <div title="Dropzone">
         <Dropzone
@@ -646,20 +635,7 @@ const TableListView: React.FC<TableListViewProps> = ({
           element.property == ConfigProperty.COLUMN_DISPLAY_TYPE
       );
 
-      if (column.is_editable == false) {
-        localStorage.setItem(
-          "currentPrimaryKeyValue",
-          currentRow.row[column.column_name]
-        );
-      }
-
-      if (column.references_table != null) {
-        const string = column.column_name + "LL";
-        localStorage.setItem(
-          string,
-          currentRow.row[column.column_name] as string
-        );
-      }
+     
       if (
         !columnDisplayType ||
         columnDisplayType.value == "text" ||

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -845,7 +845,7 @@ const TableListView: React.FC<TableListViewProps> = ({
     if (!table.has_details_view) {
       return;
     }
-    if (table.stand_alone_details_view) {
+    if (!table.stand_alone_details_view) {
       console.log("No Stand Alone Details View " + table.table_name);
     }
     const schema = vmd.getTableSchema(table.table_name);
@@ -866,13 +866,13 @@ const TableListView: React.FC<TableListViewProps> = ({
     setIsPopupVisible(true);
   };
 
-  useEffect(() => {
-    if (showTable) {
-      setTimeout(() => {
-        setShowTable(false);
-      }, 1000);
-    }
-  }, [openPanel]);
+  // useEffect(() => {
+  //   if (showTable) {
+  //     setTimeout(() => {
+  //       setShowTable(false);
+  //     }, 1000);
+  //   }
+  // }, [openPanel]);
 
   return (
     <div>
@@ -1242,7 +1242,7 @@ const TableListView: React.FC<TableListViewProps> = ({
               <div></div>
             ) : showTable ? (
               <div style={{ paddingBottom: "2em" }}>
-                <LookUpTableDetails table={table} />
+                <LookUpTableDetails table={table} currentRow={currentRow.row} />
               </div>
             ) : (
               <Button

--- a/UInnovateApp/src/components/TableListViewComponents/DeleteRowButton.tsx
+++ b/UInnovateApp/src/components/TableListViewComponents/DeleteRowButton.tsx
@@ -3,12 +3,14 @@ import vmd, { Table } from '../../virtualmodel/VMD';
 import { DataAccessor, Row } from '../../virtualmodel/DataAccessor';
 import { useDispatch } from 'react-redux';
 import { Button } from '@mui/material';
-import { IoIosTrash } from 'react-icons/io';
+import { MdDelete } from "react-icons/md";
 import { displayError } from '../../redux/NotificationSlice';
 import Logger from '../../virtualmodel/Logger';
 import { useSelector } from "react-redux";
 import { RootState } from "../../redux/Store";
 import { AuthState } from "../../redux/AuthSlice";
+import "../../styles/TableListView.css";
+
 interface DeleteRowProps {
   getRows: () => void;
   table: Table;
@@ -17,7 +19,7 @@ interface DeleteRowProps {
 
 const DeleteRowButton: React.FC<DeleteRowProps> =
   ({ getRows, table, row }: DeleteRowProps): ReactNode => {
-    const {user: loggedInUser }: AuthState = useSelector((state: RootState) => state.auth);
+    const { user: loggedInUser }: AuthState = useSelector((state: RootState) => state.auth);
     //for the error display message
     const dispatch = useDispatch();
     const schema = vmd.getTableSchema(table.table_name);
@@ -66,7 +68,7 @@ const DeleteRowButton: React.FC<DeleteRowProps> =
           Logger.logUserAction(
             loggedInUser || "",
             "Deleted Row",
-            "User has deleted a row in the table: "+ table.table_name+ "with primary key: "+ column_name + " = " + column_value,
+            "User has deleted a row in the table: " + table.table_name + "with primary key: " + column_name + " = " + column_value,
             schema?.schema_name || "",
             table.table_name
 
@@ -75,10 +77,10 @@ const DeleteRowButton: React.FC<DeleteRowProps> =
           if (error) {
             dispatch(displayError(`The row could not be deleted due to dependencies with ${referencedTables}.`));
           }
-          
+
         }
-        
-    
+
+
         getRows();
 
       }
@@ -99,7 +101,7 @@ const DeleteRowButton: React.FC<DeleteRowProps> =
           Logger.logUserAction(
             loggedInUser || "",
             "Deleted Row",
-            "User has deleted a row in the table: "+ table.table_name,
+            "User has deleted a row in the table: " + table.table_name,
             schema?.schema_name || "",
             table.table_name
           );
@@ -109,7 +111,7 @@ const DeleteRowButton: React.FC<DeleteRowProps> =
             dispatch(displayError(`The row could not be deleted due to dependencies with ${referencedTables}.`));
           }
         }
-        
+
         getRows();
 
       }
@@ -143,7 +145,7 @@ const DeleteRowButton: React.FC<DeleteRowProps> =
 
         }}
       >
-        <IoIosTrash size="1.5em" />
+        <MdDelete size="1.5em" className="delete-icon" />
       </Button></>);
 
   }

--- a/UInnovateApp/src/components/TableListViewComponents/LookUpTableDetails.tsx
+++ b/UInnovateApp/src/components/TableListViewComponents/LookUpTableDetails.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
-import vmd, { Column, Table } from "../../virtualmodel/VMD";
+import vmd, { Column, Table, } from "../../virtualmodel/VMD";
 import { DataAccessor, Row } from "../../virtualmodel/DataAccessor";
-import TableComponent from "react-bootstrap/Table";
 import {
   Table as TableMUI,
   TableBody,
@@ -14,147 +13,141 @@ import {
 
 interface TableListViewProps {
   table: Table;
+  currentRow: Row;
 }
 
-const LookUpTableDetails: React.FC<TableListViewProps> = 
-({ table }: TableListViewProps) => {
+const LookUpTableDetails: React.FC<TableListViewProps> =
+  ({ table, currentRow }: TableListViewProps) => {
 
-  const [Columns, setColumns] = useState<Column[][]>([]);
-  const [rows, setRows] = useState<Row[][] | undefined>([]);
-  const getTable = JSON.parse(table.lookup_tables);
-  const count = Object.keys(getTable).length - 1;
+    const [Columns, setColumns] = useState<Column[][]>([]);
+    const [rows, setRows] = useState<Row[][] | undefined>([]);
+    const getTable = JSON.parse(table.lookup_tables);
+    const count = Object.keys(getTable).length - 1;
+    const LookUpTables = (num: number) => {
+      num = num - 1;
 
-  
-  const LookUpTables = (num: number) => {
-    num = num - 1;
-
-    if (getTable[num] == 'none') {
-      return (<></>);
-    }
-    else {
-
-      const tableName = getTable[num];
-      const search = table.getColumns()
-
-      let toolsColumnName: string = "";
-      let toolsColumn: string = "";
-      search?.map((attribute) => {
-        if (attribute.references_table == tableName) {
-          toolsColumnName = attribute.references_by;
-          toolsColumn = attribute.column_name;
+      if (getTable[num] == 'none') {
+        return (<></>);
+      }
+      else {
+        console.log(currentRow);
+        const attributes = table.getColumns();
+        const lookup: string[] = getTable[num].split(':');
+        const tableName = lookup[0].trim();
+        const column = lookup[1].trim();
+        let columnValue = currentRow[column];
+        if (columnValue == undefined) {
+          attributes?.map((attribute) => {
+            if (attribute.is_editable == false) {
+              columnValue = currentRow[attribute.column_name];
+            }
+          });
         }
-        else {
-          return (<>no</>);
-        }
-      });
 
-      const connectionID = localStorage.getItem(toolsColumn + "LL");
-      if (connectionID == undefined) {
-        return (<>Missing ConnectionID {toolsColumn}</>);
+
+
+
+        useEffect(() => {
+
+          const getRows = async () => {
+            const schemaObj = vmd.getTableSchema(tableName)
+            if (!schemaObj) {
+              return (<>SchemaObj did not work</>);
+            }
+            const tableObj = vmd.getTable(schemaObj.schema_name, tableName);
+            if (!tableObj) {
+              return (<>tableObj did not work</>);
+            }
+            const Colss = tableObj.getColumns();
+            setColumns(prevColumns => [...prevColumns, Colss]);
+            const data_accessor: DataAccessor = vmd.getRowsDataAccessorForLookUpTable(
+              schemaObj.schema_name,
+              tableName,
+              column,
+              columnValue
+            );
+            console.log(data_accessor);
+            const lines = await data_accessor.fetchRows();
+            if (!lines) {
+              return console.error("Could not fetch rows");
+            }
+            // Filter the rows to only include the visible columns
+            const filteredRows = lines?.map((row) => {
+              const filteredRowData: { [key: string]: string | number | boolean } =
+                {};
+              Colss.forEach((column) => {
+                filteredRowData[column.column_name] = row[column.column_name];
+              });
+              return (filteredRowData);
+            });
+            setRows(prevRows => [...prevRows, filteredRows]);
+
+          };
+          getRows();
+        }, [num, columnValue, tableName, column]);
+
+        return (
+          <div>
+            {tableName} look up table:
+            <div>
+              {/* Here is the table name: {toolsColumn} */}
+            </div>
+            {Columns[num + 1] && rows[num + 1] ? (
+              <TableContainer style={{ marginBottom: '2em' }}>
+                <TableMUI
+                  className="table-container"
+                  size="medium"
+                  sx={{ border: "1px solid lightgrey" }}
+                  style={{ padding: '10px' }}
+                  data-testid="table"
+                >
+                  <TableHead>
+                    <TableRow >
+                      {Columns[num + 1].map((column) => {
+                        return <TableCell key={column.column_name}>{column.column_name}</TableCell>;
+                      })}
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {Array.isArray(rows[num + 1]) && rows[num + 1].map((row, rowIdx) => (
+                      <TableRow key={rowIdx} sx={{ backgroundColor: '#f2f2f2' }}>
+                        {Object.values(row).map((cell, idx) => (
+                          <TableCell key={idx} >
+                            {cell !== null && cell !== undefined && typeof cell !== 'object' ? cell.toString() : ''}
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </TableMUI>
+              </TableContainer>
+            ) : (
+              <p>Loading...</p>
+            )}
+
+          </div>
+
+
+        )
+
       }
 
-
-      useEffect(() => {
-
-        const getRows = async () => {
-          const schemaObj = vmd.getTableSchema(tableName)
-          if (!schemaObj) {
-            return (<>SchemaObj did not work</>);
-          }
-          const tableObj = vmd.getTable(schemaObj.schema_name, tableName);
-          if (!tableObj) {
-            return (<>tableObj did not work</>);
-          }
-          const Colss = tableObj.getColumns();
-          setColumns(prevColumns => [...prevColumns, Colss]);
-          const data_accessor: DataAccessor = vmd.getRowsDataAccessorForLookUpTable(
-            schemaObj.schema_name,
-            tableName,
-            toolsColumnName,
-            connectionID
-          );
-          console.log(data_accessor);
-          const lines = await data_accessor.fetchRows();
-          if (!lines) {
-            return console.error("Could not fetch rows");
-          }
-          // Filter the rows to only include the visible columns
-          const filteredRows = lines?.map((row) => {
-            const filteredRowData: { [key: string]: string | number | boolean } =
-              {};
-            Colss.forEach((column) => {
-              filteredRowData[column.column_name] = row[column.column_name];
-            });
-            return (filteredRowData);
-          });
-          setRows(prevRows => [...prevRows, filteredRows]);
-
-        };
-        getRows();
-      }, [num, tableName, toolsColumnName, toolsColumn, connectionID]);
-
-      return (
-        <div>
-          {tableName} look up table:
-          <div>
-            {/* Here is the table name: {toolsColumn} */}
-          </div>
-          {Columns[num + 1] && rows[num + 1] ? (
-            <TableContainer style={{ marginBottom: '2em' }}>
-              <TableMUI 
-                className="table-container"
-                size="medium"
-                sx={{ border: "1px solid lightgrey" }}
-                style={{ padding: '10px' }}
-                data-testid="table"
-              >
-                <TableHead>
-                  <TableRow >
-                    {Columns[num + 1].map((column) => {
-                      return <TableCell key={column.column_name}>{column.column_name}</TableCell>;
-                    })}
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {Array.isArray(rows[num + 1]) && rows[num + 1].map((row, rowIdx) => (
-                    <TableRow key={rowIdx} sx={{backgroundColor:'#f2f2f2'}}>
-                      {Object.values(row).map((cell, idx) => (
-                        <TableCell key={idx} >
-                          {cell !== null && cell !== undefined && typeof cell !== 'object' ? cell.toString() : ''}
-                          </TableCell>
-                      ))}
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </TableMUI>
-            </TableContainer>
-          ) : (
-            <p>Loading...</p>
-          )}
-
-        </div>
-
-
-      )
-
     }
 
+
+    return (<>
+      {[...Array(count)].map((_, index) => (
+        <div key={index}>
+          {LookUpTables(index)}
+        </div>
+
+      ))}
+    </>
+    )
+
+
+
+
   }
-
-
-  return (<>
-    {[...Array(count)].map((_, index) => (
-      <div key={index}>
-        {LookUpTables(index)}
-      </div>
-
-    ))}
-  </>
-  )
-
-
-
-
-}
 
 export default LookUpTableDetails;

--- a/UInnovateApp/src/components/TableListViewComponents/LookUpTableDetails.tsx
+++ b/UInnovateApp/src/components/TableListViewComponents/LookUpTableDetails.tsx
@@ -21,25 +21,22 @@ const LookUpTableDetails: React.FC<TableListViewProps> =
 
     const [Columns, setColumns] = useState<Column[][]>([]);
     const [rows, setRows] = useState<Row[][] | undefined>([]);
-    console.log(table.lookup_tables);
     const getTable = JSON.parse(table.lookup_tables);
-    const count = Object.keys(getTable).length - 1;
+    const count = Object.keys(getTable).length - 1; // -1 to account for the row key and checks for the number of look up tables that are present
     const LookUpTables = (num: number) => {
       num = num - 1;
-
+      //if not settings are present for look up tables
       if (getTable[num] == 'none') {
         return (<></>);
       }
       else {
-        console.log(currentRow);
         const attributes = table.getColumns();
-        console.log(attributes);
         const value = getTable[num].split(':');
         const tableName = value[0].trim();
         const type = value[1].trim();
-        console.log(type)
         let column = 'bruh';
         attributes?.map((attribute) => {
+          //checks for references table and referenced table
           if (type == 'references') {
             if (attribute.references_table == tableName) {
               column = attribute.references_by;
@@ -88,7 +85,6 @@ const LookUpTableDetails: React.FC<TableListViewProps> =
               column,
               columnValue
             );
-            console.log(data_accessor);
             const lines = await data_accessor.fetchRows();
             if (!lines) {
               return console.error("Could not fetch rows");
@@ -117,7 +113,7 @@ const LookUpTableDetails: React.FC<TableListViewProps> =
               {tableName} {type} look up table:
             </div>
             <div>
-              {/* Here is the table name: {toolsColumn} */}
+              
             </div>
             {Columns[num + 1] && rows[num + 1] ? (
               <TableContainer style={{ marginBottom: '2em' }} >

--- a/UInnovateApp/src/components/TableListViewComponents/LookUpTableDetails.tsx
+++ b/UInnovateApp/src/components/TableListViewComponents/LookUpTableDetails.tsx
@@ -33,9 +33,30 @@ const LookUpTableDetails: React.FC<TableListViewProps> =
       else {
         console.log(currentRow);
         const attributes = table.getColumns();
-        const lookup: string[] = getTable[num].split(':');
-        const tableName = lookup[0].trim();
-        const column = lookup[1].trim();
+        console.log(attributes);
+        const value = getTable[num].split(':');
+        const tableName = value[0].trim();
+        const type = value[1].trim();
+        console.log(type)
+        let column = 'bruh';
+        attributes?.map((attribute) => {
+          if (type == 'references') {
+            if (attribute.references_table == tableName) {
+              column = attribute.references_by;
+            }
+          }
+          if (type == 'referenced') {
+            if (attribute.referenced_table != null && attribute.referenced_table != "null") {
+              attribute.referenced_table.split(',').map((table) => {
+                if (table.trim() == tableName) {
+                  column = attribute.referenced_by;
+                }
+              }
+              );
+            }
+          }
+        });
+
         let columnValue = currentRow[column];
         if (columnValue == undefined) {
           attributes?.map((attribute) => {
@@ -85,15 +106,15 @@ const LookUpTableDetails: React.FC<TableListViewProps> =
 
           };
           getRows();
-        }, [num, columnValue, tableName, column]);
+        }, [num, columnValue, tableName, column, currentRow, attributes]);
 
         return (
           <div>
-            <div 
-            style={{ marginLeft: '12px' }}
-            data-testid="look-up-table-text"
+            <div
+              style={{ marginLeft: '12px' }}
+              data-testid="look-up-table-text"
             >
-              {tableName} look up table:
+              {tableName} {type} look up table:
             </div>
             <div>
               {/* Here is the table name: {toolsColumn} */}

--- a/UInnovateApp/src/components/TableListViewComponents/LookUpTableDetails.tsx
+++ b/UInnovateApp/src/components/TableListViewComponents/LookUpTableDetails.tsx
@@ -21,6 +21,7 @@ const LookUpTableDetails: React.FC<TableListViewProps> =
 
     const [Columns, setColumns] = useState<Column[][]>([]);
     const [rows, setRows] = useState<Row[][] | undefined>([]);
+    console.log(table.lookup_tables);
     const getTable = JSON.parse(table.lookup_tables);
     const count = Object.keys(getTable).length - 1;
     const LookUpTables = (num: number) => {
@@ -88,18 +89,23 @@ const LookUpTableDetails: React.FC<TableListViewProps> =
 
         return (
           <div>
-            {tableName} look up table:
+            <div 
+            style={{ marginLeft: '12px' }}
+            data-testid="look-up-table-text"
+            >
+              {tableName} look up table:
+            </div>
             <div>
               {/* Here is the table name: {toolsColumn} */}
             </div>
             {Columns[num + 1] && rows[num + 1] ? (
-              <TableContainer style={{ marginBottom: '2em' }}>
+              <TableContainer style={{ marginBottom: '2em' }} >
                 <TableMUI
                   className="table-container"
                   size="medium"
                   sx={{ border: "1px solid lightgrey" }}
                   style={{ padding: '10px' }}
-                  data-testid="table"
+                  data-testid="lookUp-table"
                 >
                   <TableHead>
                     <TableRow >

--- a/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
+++ b/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
@@ -18,11 +18,8 @@ import Audits from "../../virtualmodel/Audits";
 type LookUpTableProps = {
   table: Table;
 }
-type DefaultRow = {
-  [key: number]: string;
-};
 
-const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) => {
+const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) => {
   const attributes = table.getColumns();
   let count = 0;
   const referencesTableList: string[] = [];
@@ -44,11 +41,7 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
     }
   });
   if (count == 0) {
-
-
-    return (<div>
-
-    </div>)
+    return (<></>)
   }
   else {
 
@@ -79,7 +72,10 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
 
           <FormControl size="small">
             <h6>Lookup Tables</h6>
-            <Select onChange={HandleChange(buttonIndex)} value={SelectInput[buttonIndex] == undefined ? "error" : SelectInput[buttonIndex]}>
+            <Select onChange={HandleChange(buttonIndex)} 
+            value={SelectInput[buttonIndex] == undefined ? "error" : SelectInput[buttonIndex]}
+            data-testid = "lookup-tables-component"
+            >
               <MenuItem value={"none"} >None</MenuItem>
               {referencesTableList.map((ref, index) => (
                 <MenuItem value={ref} key={index}>
@@ -218,7 +214,10 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
 
           <FormControl style={{ marginRight: '30px' }} size="small">
             <h6>Lookup Tables</h6>
-            <Select onChange={HandleChange(-1)} value={SelectInput[-1] == undefined ? "error" : SelectInput[-1]}>
+            <Select onChange={HandleChange(-1)} 
+            value={SelectInput[-1] == undefined ? "error" : SelectInput[-1]}
+            data-testid = "lookup-tables-initial"
+            >
               <MenuItem value={"none"} >None</MenuItem>
               {referencesTableList.map((ref, index) => (
                 <MenuItem key={index} value={ref}>
@@ -234,12 +233,14 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
           <button
             onClick={handleButtonClick}
             style={{ width: '26.5px', height: '30px', marginRight: '30px' }}
+            data-testid = "initial-plus-button"
           >
             +
           </button>
           <button
             onClick={handleButtonClickDelete}
             style={{ width: '26.5px', height: '30px', }}
+            data-testid = "initial-minus-button"
           >
             -
           </button>
@@ -255,6 +256,6 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
     );
   }
 };
-export default LookUpTable;
+export default LookUpTableSetting;
 
 

--- a/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
+++ b/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
@@ -13,7 +13,7 @@ import { saveConfigToDB } from '../../helper/SettingsHelpers';
 import { AuthState } from '../../redux/AuthSlice';
 import { RootState } from '../../redux/Store';
 import { useSelector } from 'react-redux';
-import  Audits  from "../../virtualmodel/Audits";
+import Audits from "../../virtualmodel/Audits";
 
 type LookUpTableProps = {
   table: Table;
@@ -26,11 +26,18 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
   const attributes = table.getColumns();
   let count = 0;
   const referencesTableList: string[] = [];
-  const {user: loggedInUser }: AuthState = useSelector((state: RootState) => state.auth);
+  const { user: loggedInUser }: AuthState = useSelector((state: RootState) => state.auth);
   attributes?.map((attribute) => {
     if (attribute.references_table != "null" && attribute.references_table != null) {
       count = count + 1;
-      referencesTableList.push(attribute.references_table);
+      referencesTableList.push(attribute.references_table + " : " + attribute.references_by);
+    }
+    if (attribute.referenced_table != "null" && attribute.referenced_table != null) {
+      const tables = attribute.referenced_table.split(','); 
+      tables.forEach(table => { 
+        count = count + 1;
+        referencesTableList.push(table.trim() + " : " + attribute.referenced_by);
+      });
     }
     else {
       count = count + 0;
@@ -81,7 +88,7 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
               ))}
             </Select>
             <FormHelperText>
-              To customize the table which will be looked up
+              Format of look up table = Table : Column
             </FormHelperText>
           </FormControl>
         </div>
@@ -109,7 +116,7 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
         "Lookup Tables",
         "User changed the lookup counter of the table to " + counter.toString(),
         "",
-        table.table_name) 
+        table.table_name)
     };
 
     const setSelectInputConfig = async (selectInput: Row) => {
@@ -220,7 +227,7 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
               ))}
             </Select>
             <FormHelperText>
-              To customize the table which will be looked up
+            Format of look up table = Table : Column
             </FormHelperText>
           </FormControl>
 

--- a/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
+++ b/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
@@ -88,7 +88,7 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
               ))}
             </Select>
             <FormHelperText>
-              Format of look up table = Table : Column
+            Table : Column, column is references or referenced by
             </FormHelperText>
           </FormControl>
         </div>
@@ -176,7 +176,7 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
         table.table_name)
     };
 
-    const handleButtonClickDelete = () => {
+    const handleButtonClickDelete = async () => {
       if (counter > 0) {
         const newCounterValue = counter - 1;
         setCounter(newCounterValue);
@@ -194,7 +194,7 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
         table.table_name)
     };
 
-    const handleReset = () => {
+    const handleReset = async() => {
       const newSelectInput = {
         ...SelectInput,
         [counter - 1]: "none"
@@ -227,7 +227,7 @@ const LookUpTable: React.FC<LookUpTableProps> = ({ table }: LookUpTableProps) =>
               ))}
             </Select>
             <FormHelperText>
-            Format of look up table = Table : Column
+            Table : Column, column is references or referenced by
             </FormHelperText>
           </FormControl>
 

--- a/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
+++ b/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
@@ -27,13 +27,15 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
   attributes?.map((attribute) => {
     if (attribute.references_table != "null" && attribute.references_table != null) {
       count = count + 1;
-      referencesTableList.push(attribute.references_table + " : " + attribute.references_by);
+      referencesTableList.push(attribute.references_table + ":references");
     }
     if (attribute.referenced_table != "null" && attribute.referenced_table != null) {
-      const tables = attribute.referenced_table.split(','); 
-      tables.forEach(table => { 
-        count = count + 1;
-        referencesTableList.push(table.trim() + " : " + attribute.referenced_by);
+      const tables = attribute.referenced_table.split(',');
+      tables.forEach(table => {
+       
+          count = count + 1;
+          referencesTableList.push(table.trim() + ":referenced");
+        
       });
     }
     else {
@@ -72,9 +74,9 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
 
           <FormControl size="small">
             <h6>Lookup Tables</h6>
-            <Select onChange={HandleChange(buttonIndex)} 
-            value={SelectInput[buttonIndex] == undefined ? "error" : SelectInput[buttonIndex]}
-            data-testid = "lookup-tables-component"
+            <Select onChange={HandleChange(buttonIndex)}
+              value={SelectInput[buttonIndex] == undefined ? "error" : SelectInput[buttonIndex]}
+              data-testid="lookup-tables-component"
             >
               <MenuItem value={"none"} >None</MenuItem>
               {referencesTableList.map((ref, index) => (
@@ -84,7 +86,7 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
               ))}
             </Select>
             <FormHelperText>
-            Table : Column, column is references or referenced by
+            References means current table references selected table
             </FormHelperText>
           </FormControl>
         </div>
@@ -190,7 +192,7 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
         table.table_name)
     };
 
-    const handleReset = async() => {
+    const handleReset = async () => {
       const newSelectInput = {
         ...SelectInput,
         [counter - 1]: "none"
@@ -214,9 +216,9 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
 
           <FormControl style={{ marginRight: '30px' }} size="small">
             <h6>Lookup Tables</h6>
-            <Select onChange={HandleChange(-1)} 
-            value={SelectInput[-1] == undefined ? "error" : SelectInput[-1]}
-            data-testid = "lookup-tables-initial"
+            <Select onChange={HandleChange(-1)}
+              value={SelectInput[-1] == undefined ? "error" : SelectInput[-1]}
+              data-testid="lookup-tables-initial"
             >
               <MenuItem value={"none"} >None</MenuItem>
               {referencesTableList.map((ref, index) => (
@@ -226,21 +228,21 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
               ))}
             </Select>
             <FormHelperText>
-            Table : Column, column is references or referenced by
+            References means current table references selected table
             </FormHelperText>
           </FormControl>
 
           <button
             onClick={handleButtonClick}
             style={{ width: '26.5px', height: '30px', marginRight: '30px' }}
-            data-testid = "initial-plus-button"
+            data-testid="initial-plus-button"
           >
             +
           </button>
           <button
             onClick={handleButtonClickDelete}
             style={{ width: '26.5px', height: '30px', }}
-            data-testid = "initial-minus-button"
+            data-testid="initial-minus-button"
           >
             -
           </button>

--- a/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
+++ b/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
@@ -1,12 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import Switch from "@mui/material/Switch";
 import FormControl from "@mui/material/FormControl";
 import FormHelperText from "@mui/material/FormHelperText";
-import Select, { SelectChangeEvent } from "@mui/material/Select";
+import Select from "@mui/material/Select";
 import { MenuItem } from '@mui/material';
 import "../../styles/TableItem.css";
 import { ConfigData, Table } from "../../virtualmodel/VMD";
-import buttonStyle from '../TableEnumView'
 import { Row } from '../../virtualmodel/DataAccessor';
 import { ConfigProperty } from '../../virtualmodel/ConfigProperties';
 import { saveConfigToDB } from '../../helper/SettingsHelpers';
@@ -25,6 +23,7 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
   const referencesTableList: string[] = [];
   const { user: loggedInUser }: AuthState = useSelector((state: RootState) => state.auth);
   attributes?.map((attribute) => {
+    //checks for references table and referenced table
     if (attribute.references_table != "null" && attribute.references_table != null) {
       count = count + 1;
       referencesTableList.push(attribute.references_table + ":references");
@@ -32,21 +31,22 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
     if (attribute.referenced_table != "null" && attribute.referenced_table != null) {
       const tables = attribute.referenced_table.split(',');
       tables.forEach(table => {
-       
-          count = count + 1;
-          referencesTableList.push(table.trim() + ":referenced");
-        
+
+        count = count + 1;
+        referencesTableList.push(table.trim() + ":referenced");
+
       });
     }
     else {
       count = count + 0;
     }
   });
+  //if there are no references or referenced tables
   if (count == 0) {
     return (<></>)
   }
   else {
-
+    //if there are references or referenced tables
     const defaultRow = new Row({});
     for (let i = -1; i < count - 1; i++) {
 
@@ -67,7 +67,7 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
     )
 
 
-
+    //button component for when we have multiple references or referenced tables and want more than 1 lookup table
     const MyButtonComponent = ({ buttonIndex }: { buttonIndex: number }) => {
       return (
         <div style={{ marginTop: '2em' }} >
@@ -86,7 +86,7 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
               ))}
             </Select>
             <FormHelperText>
-            References means current table references selected table
+              References means current table references selected table
             </FormHelperText>
           </FormControl>
         </div>
@@ -138,7 +138,7 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
     };
 
 
-
+    //function to handle change in the select input
     const HandleChange = (index: number) => (event: React.ChangeEvent<{ value: unknown }>) => {
       const newSelectInput = {
         ...SelectInput,
@@ -155,7 +155,7 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
         table.table_name)
     };
 
-
+    //function to handle increase in amount of lookup tables
     const handleButtonClick = async () => {
       if (count - 1 == counter || count == 0) {
         alert("You can't add more lookup tables")
@@ -228,7 +228,7 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
               ))}
             </Select>
             <FormHelperText>
-            References means current table references selected table
+              References means current table references selected table
             </FormHelperText>
           </FormControl>
 
@@ -249,7 +249,7 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', marginLeft: '100px', width: '273.08' }}>
           {[...Array(counter)].map((_, index) => (
-
+            //button component for when we have multiple references or referenced tables and want more than 1 lookup table
             <MyButtonComponent key={index} buttonIndex={index} />
 
           ))}

--- a/UInnovateApp/src/components/settingsPage/TableConfigTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/TableConfigTab.tsx
@@ -8,7 +8,7 @@ import vmd, { ConfigData, Table, TableDisplayType } from "../../virtualmodel/VMD
 import "../../styles/TableItem.css";
 import { ColumnConfig } from "./ColumnConfig";
 import { ConfigProperty } from "../../virtualmodel/ConfigProperties";
-import LookUpTable from "./LookupSetting";
+import LookUpTableSetting from "./LookupSetting";
 import { saveConfigToDB } from "../../helper/SettingsHelpers";
 import { AuthState } from '../../redux/AuthSlice';
 import { RootState } from '../../redux/Store';
@@ -169,7 +169,7 @@ export const TableItem: React.FC<TableItemProps> = ({ table }) => {
 
             </div>
             <div className="details-view">
-              <LookUpTable table={table} />
+              <LookUpTableSetting table={table} />
             </div>
 
           </div>

--- a/UInnovateApp/src/styles/TableListView.css
+++ b/UInnovateApp/src/styles/TableListView.css
@@ -40,3 +40,7 @@ input[type="number"]::-webkit-outer-spin-button {
 .width {
   width: 50%;
 }
+
+.delete-icon:hover {
+  color: red;
+}

--- a/UInnovateApp/src/tests/components/TableListViewComponents/LookUpTableDetails.test.tsx
+++ b/UInnovateApp/src/tests/components/TableListViewComponents/LookUpTableDetails.test.tsx
@@ -1,31 +1,54 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import { Table } from "../../../virtualmodel/VMD";
+import VMD from "../../../virtualmodel/__mocks__/VMD";
 import LookUpTableDetails from '../../../components/TableListViewComponents/LookUpTableDetails';
 
-// Mocking the vmd module
-import Table from "react-bootstrap/Table"; // Replace 'path/to/Table' with the actual path to the Table type
 
-const mockTable: typeof Table = {
-    lookup_tables: '{"1": "table1", "2": "table2"}',
-    getColumns: () => [],
-};
 
-const renderComponent = () => render(<LookUpTableDetails table={mockTable} table_name="" table_display_type="" is_visible={false} has_details_view={false} />);
+const table = new Table("table");
+const table2 = new Table("table");
+
+table.setLookupTables('{"row":{},"-1":"unit_scheduler : availability_status_id"}');
+table2.setLookupTables('{"row":{},"-1":"none"}');
+
+const row = { row: { id: '1' } };
+
+
+const renderComponent = () => render(<LookUpTableDetails table={table} currentRow={row} />);
 
 describe('LookUpTableDetails component', () => {
 
-  it('renders the component with "Missing ConnectionID" state', async () => {
-    globalThis.fetch = async () => ({
-      json: async () => [{ /* Mock row data */ }],
-    } as Response);
+
+
+  it('renders text and runs the accessor', async () => {
 
     renderComponent();
+    expect(VMD.getRowsDataAccessorForLookUpTable).toHaveBeenCalled();
 
-    // Wait for the asynchronous operations to complete
     await waitFor(() => {
-      // Check for the presence of "Missing ConnectionID"
-      const missingConnectionIDElement = screen.queryByText(/Missing ConnectionID/i);
-      expect(missingConnectionIDElement).toBeInTheDocument();
+      const tabletext = screen.getByTestId('look-up-table-text')
+      expect(tabletext).toBeInTheDocument(); // Check the first button
     });
   });
+
+  it('renders the table', async () => {
+    renderComponent();
+    expect(VMD.getRowsDataAccessorForLookUpTable).toHaveBeenCalled();
+
+    await waitFor(() => {
+      const tableElement = screen.getByTestId("lookUp-table");
+      expect(tableElement).toBeInTheDocument();
+    });
+  });
+
+  it('checks if nothing shows', async () => {
+    const { container } = render(<LookUpTableDetails table={table2} currentRow={row} />);
+
+    expect(container.firstChild).toBeEmptyDOMElement();
+  });
+
+
+
 });

--- a/UInnovateApp/src/tests/components/TableListViewComponents/LookUpTableDetails.test.tsx
+++ b/UInnovateApp/src/tests/components/TableListViewComponents/LookUpTableDetails.test.tsx
@@ -34,7 +34,7 @@ describe('LookUpTableDetails component', () => {
     });
   });
 
-  it('renders the table', async () => {
+  it('renders a table', async () => {
     renderComponent();
     expect(VMD.getRowsDataAccessorForLookUpTable).toHaveBeenCalled();
 
@@ -44,7 +44,7 @@ describe('LookUpTableDetails component', () => {
     });
   });
 
-  it('checks if nothing shows', async () => {
+  it('checks if nothing shows for when settings have nothing', async () => {
     const { container } = render(<LookUpTableDetails table={table2} currentRow={row} />);
 
     expect(container.firstChild).toBeEmptyDOMElement();
@@ -60,8 +60,6 @@ describe('LookUpTableDetails component', () => {
       expect(tableElement.length).toBeGreaterThan(1);
       const tabletext = screen.getAllByTestId('look-up-table-text')
       expect(tabletext.length).toBeGreaterThan(1);
-
-
     });
   });
 

--- a/UInnovateApp/src/tests/components/TableListViewComponents/LookUpTableDetails.test.tsx
+++ b/UInnovateApp/src/tests/components/TableListViewComponents/LookUpTableDetails.test.tsx
@@ -9,10 +9,11 @@ import LookUpTableDetails from '../../../components/TableListViewComponents/Look
 
 const table = new Table("table");
 const table2 = new Table("table");
+const table3 = new Table("table");
 
-table.setLookupTables('{"row":{},"-1":"unit_scheduler : availability_status_id"}');
+table.setLookupTables('{"row":{},"-1":"unit_scheduler:referenced"}');
 table2.setLookupTables('{"row":{},"-1":"none"}');
-
+table3.setLookupTables('{"0":"company:referenced","row":{},"-1":"company:references"}');
 const row = { row: { id: '1' } };
 
 
@@ -47,6 +48,21 @@ describe('LookUpTableDetails component', () => {
     const { container } = render(<LookUpTableDetails table={table2} currentRow={row} />);
 
     expect(container.firstChild).toBeEmptyDOMElement();
+  });
+
+  it('renders multiple tables', async () => {
+    render(<LookUpTableDetails table={table3} currentRow={row} />);
+
+    expect(VMD.getRowsDataAccessorForLookUpTable).toHaveBeenCalled();
+
+    await waitFor(() => {
+      const tableElement = screen.getAllByTestId("lookUp-table");
+      expect(tableElement.length).toBeGreaterThan(1);
+      const tabletext = screen.getAllByTestId('look-up-table-text')
+      expect(tabletext.length).toBeGreaterThan(1);
+
+
+    });
   });
 
 

--- a/UInnovateApp/src/tests/components/settingsPage/LookupSetting.test.tsx
+++ b/UInnovateApp/src/tests/components/settingsPage/LookupSetting.test.tsx
@@ -53,7 +53,7 @@ describe('LookupSetting component', () => {
 
     });
 
-    it('testing buttons where there are multiple tables', async () => {
+    it('testing buttons when there are multiple tables', async () => {
 
         render(
             <Provider store={store}>
@@ -79,14 +79,14 @@ describe('LookupSetting component', () => {
 
     });
 
-    it('checks if nothing shows', async () => {
-        const { container } =  render(
+    it('checks if nothing shows for tables with no referencing', async () => {
+        const { container } = render(
             <Provider store={store}>
                 <LookUpTableSetting table={table3} />
             </Provider>
         );
-    
+
         expect(container.firstChild).toBeNull();
     });
-    
+
 });

--- a/UInnovateApp/src/tests/components/settingsPage/LookupSetting.test.tsx
+++ b/UInnovateApp/src/tests/components/settingsPage/LookupSetting.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import configureStore from "redux-mock-store";
+import { Column, Table } from "../../../virtualmodel/VMD";
+import LookUpTableSetting from '../../../components/settingsPage/LookupSetting';
+import { Store, Middleware } from "@reduxjs/toolkit";
+import { Provider } from 'react-redux';
+import { Role } from "../../../redux/AuthSlice";
+
+
+
+const initialState = {
+    schema: { schema_name: "application" },
+    script_table: { table_name: "script_mock" },
+    auth: { role: Role.ADMIN, user: "admin", token: "token", schema_access: ['mock schema name'] } //See VMD mock for reference to schema_access table
+};
+
+const middlewares: Middleware[] = [];
+const mockStore = configureStore(middlewares);
+const store: Store = mockStore(initialState);
+const table = new Table("example");
+const table2 = new Table("example2");
+const table3 = new Table("example3");
+const columns = [
+    new Column("Column1"),
+    new Column("Column2"),
+];
+
+
+table.addColumn(columns[0], "reference", true, 'reference_id', 'null', 'null');
+table2.addColumn(columns[0], "reference", true, 'reference_id', 'referencess', 'referencess_id');
+table3.addColumn(columns[1], 'null', true, 'null', 'null', 'null');
+
+describe('LookupSetting component', () => {
+
+
+
+    it('renders when table only has 1 references table', async () => {
+
+        render(
+            <Provider store={store}>
+                <LookUpTableSetting table={table} />
+            </Provider>
+        );
+        const initialSelect = screen.getByTestId('lookup-tables-initial')
+        expect(initialSelect).toBeInTheDocument();
+
+        const initialPlus = screen.getByTestId('initial-plus-button')
+        expect(initialPlus).toBeInTheDocument();
+
+        const initialMinus = screen.getByTestId('initial-minus-button')
+        expect(initialMinus).toBeInTheDocument();
+
+    });
+
+    it('testing buttons where there are multiple tables', async () => {
+
+        render(
+            <Provider store={store}>
+                <LookUpTableSetting table={table2} />
+            </Provider>
+        );
+        const initialSelect = screen.getByTestId('lookup-tables-initial')
+        expect(initialSelect).toBeInTheDocument();
+
+        const initialPlus = screen.getByTestId('initial-plus-button')
+        expect(initialPlus).toBeInTheDocument();
+
+        const initialMinus = screen.getByTestId('initial-minus-button')
+        expect(initialMinus).toBeInTheDocument();
+        act(() => initialPlus.click());
+
+        const SelectComponent = screen.getByTestId('lookup-tables-component')
+        expect(SelectComponent).toBeInTheDocument();
+
+        act(() => initialMinus.click());
+
+        expect(SelectComponent).not.toBeInTheDocument();
+
+    });
+
+    it('checks if nothing shows', async () => {
+        const { container } =  render(
+            <Provider store={store}>
+                <LookUpTableSetting table={table3} />
+            </Provider>
+        );
+    
+        expect(container.firstChild).toBeNull();
+    });
+    
+});

--- a/UInnovateApp/src/virtualmodel/__mocks__/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/__mocks__/VMD.tsx
@@ -70,6 +70,10 @@ export default {
     console.log("getAddRowDataAccessor in VMD mock was called");
     return new DataAccessorMock();
   }),
+  getRowsDataAccessorForLookUpTable: vi.fn().mockImplementation(() => {
+    console.log("getRowsDataAccessorForLookUpTable in VMD mock was called");
+    return new DataAccessorMock();
+  }),
   Table: Table,
   Column: Column,
   TableDisplayType: TableDisplayType,


### PR DESCRIPTION
Related to #231  

## Changes
- Now lookup tables include tables that reference or are referenced:
For this example, this table doesn't reference any table, but table unit_scheduler references it:
![image](https://github.com/WillTrem/UInnovate/assets/92006009/132a9146-c17e-4f95-8f86-04369457dfc8)

The new select parameters being the tablename:references/referenced is because sometimes the current table references and is referenced by the same table.
![image](https://github.com/WillTrem/UInnovate/assets/92006009/31d8e169-79d6-43ac-b5ed-e85cccf23c2c)

Example in the detail view
![image](https://github.com/WillTrem/UInnovate/assets/92006009/f19f7f07-d526-4ba9-b75a-9a2873ef7b77)




## extra: 
- added test for both look-up settings and detail
- added better CSS for the delete button for better consistency 
