### PR TITLE
Added support for custom view template created using mustache templates

### DIFF
--- a/UInnovateApp/package-lock.json
+++ b/UInnovateApp/package-lock.json
@@ -34,6 +34,7 @@
         "react-datepicker": "^4.25.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.11.0",
+        "react-mustache-template-component": "^2.1.2",
         "react-number-format": "^5.3.1",
         "react-pro-sidebar": "^1.1.0-alpha.1",
         "react-redux": "^8.1.3",
@@ -7303,6 +7304,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.11.tgz",
+      "integrity": "sha512-Fan4uMuyB26gFV3ovPoEoQbxRRPfTu3CvImyZnhGq5fsIEO+gEFLp45ISFt+kQBWsK5ulDdT0oV28jS1UrwQLg=="
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -10816,6 +10822,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -12325,6 +12339,19 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-mustache-template-component": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-mustache-template-component/-/react-mustache-template-component-2.1.2.tgz",
+      "integrity": "sha512-DRYfqPTUPWeeYDG/fpPe23Fo5UOVY9FDtrdKtABHf9e5lki/o1TUf863xCNyz2xFi9whi+Q6Ap3Sci6a3cpKRw==",
+      "dependencies": {
+        "dompurify": "^3.0.5",
+        "mustache": "^4.2.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.4 || ^17.0.0 || ^18.0.0",
+        "react-dom": ">= 16.8.4 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/react-number-format": {
       "version": "5.3.1",

--- a/UInnovateApp/package.json
+++ b/UInnovateApp/package.json
@@ -43,6 +43,7 @@
     "react-datepicker": "^4.25.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.11.0",
+    "react-mustache-template-component": "^2.1.2",
     "react-number-format": "^5.3.1",
     "react-pro-sidebar": "^1.1.0-alpha.1",
     "react-redux": "^8.1.3",

--- a/UInnovateApp/src/components/AdditionalViewNavBar.tsx
+++ b/UInnovateApp/src/components/AdditionalViewNavBar.tsx
@@ -1,13 +1,11 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Container, Nav, Navbar } from "react-bootstrap";
 import {
-  AdditionalViews,
-  getCustomViews,
+  AdditionalView,
   getViewsBySchema,
 } from "../virtualmodel/AdditionalViewsDataAccessor";
 import { Table } from "../virtualmodel/VMD";
 import { ViewTypeEnum } from "../enums/ViewTypeEnum";
-import e from "express";
 
 interface AdditionalViewNavBarProp {
   selectedSchema: string;
@@ -25,15 +23,13 @@ const AdditionalViewNavBar = ({
   selectedViewType,
   selectViewHandler,
 }: AdditionalViewNavBarProp) => {
-  const [viewList, setViewList] = useState<AdditionalViews[]>([]);
-  const [customViews, setCustomViews] = useState([]);
+  const [viewList, setViewList] = useState<AdditionalView[]>([]);
 
   useEffect(() => {
     const ctrl = new AbortController();
     const signal = ctrl.signal;
     // get data from db
     getViewsBySchema(setViewList, selectedSchema, signal);
-    // getCustomViews(setCustomViews, signal)
 
     return () => {
       ctrl.abort();
@@ -53,7 +49,7 @@ const AdditionalViewNavBar = ({
   );
 };
 interface AdditionalTableViewSelectorProp {
-  views: AdditionalViews[];
+  views: AdditionalView[];
   selectedSchema: string;
   selectedTable: string | undefined;
   selectedView: ViewTypeEnum;
@@ -70,12 +66,12 @@ const AdditionalTableViewSelector = ({
   selectedView,
   selectedViewHandler,
 }: AdditionalTableViewSelectorProp) => {
-  const [filteredViews, setFilteredViews] = useState<AdditionalViews[]>([]);
+  const [filteredViews, setFilteredViews] = useState<AdditionalView[]>([]);
   const [activeView, setActiveView] = useState(0);
 
   useEffect(() => {
     setActiveView(selectedView);
-    const filteredViews = views.filter((view: AdditionalViews) => {
+    const filteredViews = views.filter((view: AdditionalView) => {
       if (view.tablename === selectedTable) return true;
       return false;
     });
@@ -102,7 +98,7 @@ const AdditionalTableViewSelector = ({
           eventKey={viewName}
           href="#"
           className={viewtype == activeView ? "active" : ""}
-          onClick={(e) => {
+          onClick={() => {
             handleActiveView(viewtype);
           }}
         >
@@ -119,7 +115,7 @@ const AdditionalTableViewSelector = ({
         <Nav className="d-flex justify-content-evenly" variant="underline">
           {navLink("default", ViewTypeEnum.Default, "Default")}
           {filteredViews.length > 0 &&
-            filteredViews.map((view: AdditionalViews) => {
+            filteredViews.map((view: AdditionalView) => {
               if (view) {
                 switch (view.viewtype) {
                   case ViewTypeEnum.Calendar:

--- a/UInnovateApp/src/components/CustomViewLoader.tsx
+++ b/UInnovateApp/src/components/CustomViewLoader.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from "react";
+import TemplateComponent from "react-mustache-template-component";
+import { useNavigate } from "react-router-dom";
+import vmd, { Column, Table } from "../virtualmodel/VMD";
+import { DataAccessor, Row } from "../virtualmodel/DataAccessor";
+
+interface CustomViewLoaderProps {
+  templateSource: string;
+  table: Table; // Assuming any data type for simplicity
+}
+
+const CustomViewLoader: React.FC<CustomViewLoaderProps> = ({
+  templateSource: templateSource,
+  table,
+}) => {
+  const navigate = useNavigate();
+  const [columns, setColumns] = useState<Column[]>([]);
+  const [rows, setRows] = useState<Row[] | undefined>([]);
+  const [rowsFilter, setRowsFilter] = useState<Row[] | undefined>([]);
+
+  const config_table = vmd.getTable("meta", "appconfig_values");
+  let defaultOrderValue = table.columns.find(
+    (column) => column.is_editable === false,
+  )?.column_name;
+  if (defaultOrderValue == undefined) {
+    defaultOrderValue = table.columns[0].column_name;
+  }
+
+  //These are all the Usestate which is used for Pagination, Sorting and Filtering for the List view of the table
+  const [PaginationValue, setPaginationValue] = useState<number>(10);
+  const [PageNumber, setPageNumber] = useState<number>(1);
+  const [Plength, setLength] = useState<number>(0);
+  const [showTable, setShowTable] = useState<boolean>(false);
+  const [sortOrder, setSortOrder] = useState("asc");
+  const [orderBy, setOrderBy] = useState(defaultOrderValue);
+  const [conditionFilter, setConditionFilter] = useState<string>("");
+  const [FilterMenu, setFilterMenu] = useState<(null | HTMLElement)[]>(
+    new Array(columns.length).fill(null),
+  );
+  const [FilterCheckedList, setFilterCheckedList] = useState<{
+    [key: string]: string[];
+  }>(() => {
+    const initialCheckedState = table.columns.reduce(
+      (acc, column) => {
+        acc[column.column_name] = [];
+        return acc;
+      },
+      {} as { [key: string]: string[] },
+    );
+
+    return initialCheckedState;
+  });
+  const getRows = async () => {
+    const attributes = table.getVisibleColumns();
+    const schemas = vmd.getTableSchema(table.table_name);
+
+    if (!schemas) {
+      return;
+    }
+
+    const data_accessor: DataAccessor = vmd.getRowsDataAccessorForOrder(
+      schemas.schema_name,
+      table.table_name,
+      orderBy,
+      sortOrder,
+      PaginationValue,
+      PageNumber,
+      conditionFilter,
+    );
+
+    const countAccessor: DataAccessor = vmd.getRowsDataAccessor(
+      schemas.schema_name,
+      table.table_name,
+    );
+    const count = await countAccessor.fetchRows();
+    const lines = await data_accessor.fetchRows();
+
+    // Filter the rows to only include the visible columns
+    const filteredRows = lines?.map((row) => {
+      const filteredRowData: { [key: string]: string | number | boolean } = {};
+      attributes.forEach((column) => {
+        filteredRowData[column.column_name] = row[column.column_name];
+      });
+      return new Row(filteredRowData);
+    });
+    const FilteredRowsCount = count?.map((row) => {
+      const filteredRowData: { [key: string]: string | number | boolean } = {};
+      attributes.forEach((column) => {
+        filteredRowData[column.column_name] = row[column.column_name];
+      });
+      return new Row(filteredRowData);
+    });
+    setColumns(attributes);
+    setRows(filteredRows);
+
+    if (conditionFilter === "") {
+      setRowsFilter(FilteredRowsCount);
+      setLength(count?.length || 0);
+    } else {
+      setRowsFilter(filteredRows);
+      setLength(lines?.length || 0);
+    }
+  };
+
+  useEffect(() => {
+    getRows().then(() => {
+      console.log(rows);
+    });
+  }, [table, orderBy, PageNumber, PaginationValue, sortOrder, conditionFilter]);
+
+  useEffect(() => {
+    return () => {};
+  }, []);
+
+  return (
+    <>
+      <TemplateComponent template={templateSource} data={{ rows: rows }} />
+    </>
+  );
+};
+
+export default CustomViewLoader;

--- a/UInnovateApp/src/pages/ObjectMenu.tsx
+++ b/UInnovateApp/src/pages/ObjectMenu.tsx
@@ -79,8 +79,28 @@ export function ObjectMenu() {
         viewType = selection[0].selectedView;
       }
       setViewType(viewType);
+
+      if (viewType == ViewTypeEnum.Custom) {
+        //update custom view index
+        const index = findIndexByTablename(p_tableName);
+        if (index > 0) {
+          setselectedCustomViewIndex(index);
+        } else {
+          setselectedCustomViewIndex(0);
+        }
+      }
     }
   };
+
+  function findIndexByTablename(tablename: string) {
+    for (let i = 0; i < customViews.length; i++) {
+      if (customViews[i].tablename === tablename) {
+        return i; // Return the index of the object with matching tablename
+      }
+    }
+    return -1; // Return -1 if the object is not found
+  }
+
   const dispatch = useDispatch();
   const { tableName } = useParams();
   const { schema } = useParams();

--- a/UInnovateApp/src/pages/ObjectMenu.tsx
+++ b/UInnovateApp/src/pages/ObjectMenu.tsx
@@ -171,7 +171,6 @@ export function ObjectMenu() {
               template: matching_template[0].template,
             };
             customTemplates = [...customTemplates, template];
-            console.log("customTemplates:", customTemplates);
           }
         });
         setCustomViews(customTemplates || []);

--- a/UInnovateApp/src/redux/Store.ts
+++ b/UInnovateApp/src/redux/Store.ts
@@ -1,9 +1,9 @@
 import { configureStore } from "@reduxjs/toolkit";
 import schemaReducer from "./SchemaSlice";
-import authReducer from './AuthSlice'
-import loadingReducer from './LoadingSlice'
+import authReducer from './AuthSlice';
+import loadingReducer from './LoadingSlice';
 import userDataReducer from './UserDataSlice';
-import notificationReducer from './NotificationSlice'
+import notificationReducer from './NotificationSlice';
 import selectedViewListReducer from './AdditionalViewSlice';
 
 // App state store

--- a/UInnovateApp/src/virtualmodel/AdditionalViewsDataAccessor.ts
+++ b/UInnovateApp/src/virtualmodel/AdditionalViewsDataAccessor.ts
@@ -32,7 +32,6 @@ export const getViewsBySchema = async (setterCallback:(args:any)=>void | undefin
 
     const rows = await data_accessor?.fetchRows(signal);
     if(rows){
-		// console.log(rows);
 		const filteredData = rows.filter(r => {if(r.schemaname == p_schemaName){return r}} )
         setterCallback && setterCallback(filteredData);
 		return filteredData;
@@ -48,7 +47,6 @@ export const getCustomViews = async (setterCallback:(args:any)=>void, signal: Ab
 
     const rows = await data_accessor?.fetchRows(signal);
     if(rows){
-		// console.log(rows);
         setterCallback(rows);
 		return rows;
     }
@@ -81,7 +79,6 @@ export const insertNewView = async (p_schemaName: string, p_tableName: string, p
 				"p_view_name": p_viewName,
 				"p_view_type_id": p_viewType
 			} as Row;
-			// console.log(data);
 			const cstm_view_data_accessor: FunctionAccessor = vmd.getFunctionAccessor(
 				SETTING_SCHEMA_NAME, // schema name
 				RPC_NAME, // remote procedure function name

--- a/UInnovateApp/src/virtualmodel/AdditionalViewsDataAccessor.ts
+++ b/UInnovateApp/src/virtualmodel/AdditionalViewsDataAccessor.ts
@@ -8,7 +8,7 @@ const SETTING_TABLE_NAME = 'additional_view_settings';
 const CUSTOM_VIEW_TABLE_NAME = 'custom_view_templates';
 const RPC_NAME = 'insert_custom_view';
 
-export interface AdditionalViews{
+export interface AdditionalView{
 	id: number;
 	viewname: string;
 	schemaname: string;
@@ -17,7 +17,13 @@ export interface AdditionalViews{
 	template?: string;
 }
 
-export const getViewsBySchema = async (setterCallback:(args:any)=>void, p_schemaName: string, signal: AbortSignal)  => {
+export interface CustomView{
+	id: number;
+	settingid: number;
+	template: string;
+}
+
+export const getViewsBySchema = async (setterCallback:(args:any)=>void | undefined, p_schemaName: string, signal: AbortSignal)  => {
 
     const data_accessor: DataAccessor = vmd.getRowsDataAccessor(
         SETTING_SCHEMA_NAME,
@@ -26,8 +32,10 @@ export const getViewsBySchema = async (setterCallback:(args:any)=>void, p_schema
 
     const rows = await data_accessor?.fetchRows(signal);
     if(rows){
-		console.log(rows);
-        setterCallback(rows.filter(r => {if(r.schemaname == p_schemaName){return r}} ));
+		// console.log(rows);
+		const filteredData = rows.filter(r => {if(r.schemaname == p_schemaName){return r}} )
+        setterCallback && setterCallback(filteredData);
+		return filteredData;
     }
 };
 
@@ -40,8 +48,9 @@ export const getCustomViews = async (setterCallback:(args:any)=>void, signal: Ab
 
     const rows = await data_accessor?.fetchRows(signal);
     if(rows){
-		console.log(rows);
+		// console.log(rows);
         setterCallback(rows);
+		return rows;
     }
 };
 
@@ -72,7 +81,7 @@ export const insertNewView = async (p_schemaName: string, p_tableName: string, p
 				"p_view_name": p_viewName,
 				"p_view_type_id": p_viewType
 			} as Row;
-			console.log(data);
+			// console.log(data);
 			const cstm_view_data_accessor: FunctionAccessor = vmd.getFunctionAccessor(
 				SETTING_SCHEMA_NAME, // schema name
 				RPC_NAME, // remote procedure function name
@@ -84,7 +93,7 @@ export const insertNewView = async (p_schemaName: string, p_tableName: string, p
 		}
 
 	} catch (error) {
-		console.error("Error in upserting view:", error);
+		// console.error("Error in upserting view:", error);
 		alert("Failed to save view.");
 	}
 };


### PR DESCRIPTION
I added the support for [mustache templates ](https://github.com/janl/mustache.js/) to create custom views.
make sure to do an npm install since I added a new package "[react-mustache-template-component](https://github.com/j3lte/react-mustache-template-component)"

To test the feature 
- download the test file
- go to additional views in the Settings
- add a new custom view for the table company with any name you want
- go to the table company in the object view
- select custom view from the view bar if not selected already

You should then be able to see the custom view consisting of a list of cards with the data

company table : [company_customview.txt](https://github.com/WillTrem/UInnovate/files/14730027/company_customview.txt)

contact table: [contact_customview.txt](https://github.com/WillTrem/UInnovate/files/14730145/contact_customview.txt)


![customView_data](https://github.com/WillTrem/UInnovate/assets/10947924/0e897574-97d0-41eb-970c-d01c2d15190d)
