### PR TITLE
Additional view update

### DIFF
--- a/UInnovateApp/src/components/CustomViewLoader.tsx
+++ b/UInnovateApp/src/components/CustomViewLoader.tsx
@@ -27,7 +27,7 @@ const CustomViewLoader: React.FC<CustomViewLoaderProps> = ({
   }
 
   //These are all the Usestate which is used for Pagination, Sorting and Filtering for the List view of the table
-  const [PaginationValue, setPaginationValue] = useState<number>(10);
+  const [PaginationValue, setPaginationValue] = useState<number>(100);
   const [PageNumber, setPageNumber] = useState<number>(1);
   const [Plength, setLength] = useState<number>(0);
   const [showTable, setShowTable] = useState<boolean>(false);
@@ -103,14 +103,19 @@ const CustomViewLoader: React.FC<CustomViewLoaderProps> = ({
   };
 
   useEffect(() => {
+    setOrderBy(table.columns[0].column_name);
     getRows().then(() => {
       console.log(rows);
     });
-  }, [table, orderBy, PageNumber, PaginationValue, sortOrder, conditionFilter]);
-
-  useEffect(() => {
-    return () => {};
-  }, []);
+  }, [
+    templateSource,
+    table,
+    orderBy,
+    PageNumber,
+    PaginationValue,
+    sortOrder,
+    conditionFilter,
+  ]);
 
   return (
     <>

--- a/UInnovateApp/src/components/settingsPage/additionalView/AdditionalViewModal.tsx
+++ b/UInnovateApp/src/components/settingsPage/additionalView/AdditionalViewModal.tsx
@@ -59,8 +59,6 @@ const AdditionalViewModal = ({
     e.preventDefault();
 
     if (form.checkValidity() === false) {
-      // e.preventDefault();
-      // e.stopPropagation();
       console.log("invalid form, redcheck data");
     } else {
       console.log("valid form, submitting");

--- a/UInnovateApp/src/pages/ObjectMenu.tsx
+++ b/UInnovateApp/src/pages/ObjectMenu.tsx
@@ -235,9 +235,7 @@ export function ObjectMenu() {
                   <CustomViewLoader
                     table={activeTable}
                     templateSource={
-                      customViews.length > 0
-                        ? customViews[selectedCustomViewIndex].template
-                        : ""
+                      customViews[selectedCustomViewIndex]?.template
                     }
                   />
                 )}

--- a/UInnovateApp/src/tests/AdditionalViewNavBar.test.tsx
+++ b/UInnovateApp/src/tests/AdditionalViewNavBar.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, act } from "@testing-library/react";
+import { Provider } from "react-redux";
+import AdditionalViewNavBar from "../components/AdditionalViewNavBar";
+import { cleanup } from "@testing-library/react";
+import store from "../redux/Store";
+import { Router } from "react-router-dom";
+
+describe("AdditionalViewNavBar component", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders without crashing", () => {
+    render(
+      <Provider store={store}>
+        <Router location={""} navigator={undefined}>
+          <AdditionalViewNavBar
+            selectedSchema="schema"
+            selectedView="view"
+            selectViewHandler={() => {}}
+          />
+        </Router>
+      </Provider>,
+    );
+  });
+});

--- a/database/useCase1/sampledata.sql
+++ b/database/useCase1/sampledata.sql
@@ -462,12 +462,26 @@ INSERT INTO meta.additional_view_settings(schemaName, tableName, viewName, viewT
 
 -- sample custom view 
 INSERT INTO meta.custom_view_templates(settingId, template) VALUES
-(4, 'import React from ''react''
-
-const HelloWorld = () => {
-  return (
-    <div>HelloWorld</div>
-  )
-}
-
-export default HelloWorld')
+(4, '
+    <div>
+      <div id="CustomView" class="container mt-5">
+        <div class="row" data-bind="foreach: sampleData">
+        {{#rows }}
+          <div class="col-md-4 mb-4">
+            <div class="card">
+              <div class="card-body">
+                <h5 class="card-title" data-bind="text: title">test</h5>
+                <p class="card-text">company_id: {{row.company_id}}</p>
+                <p class="card-text">company_name: {{row.company_name}}</p>
+                <p class="card-text">is_prev_customer: {{row.is_prev_customer}}</p>
+                <p class="card-text">pricing_rate: {{row.pricing_rate}}</p>
+                <p class="card-text">primary_contact_id: {{row.primary_contact_id}}</p>
+                <a href="#" class="btn btn-primary" data-bind="text: details">Some action</a>
+              </div>
+            </div>
+          </div>
+        {{/rows}}
+        </div>
+      </div>
+    </div>
+')


### PR DESCRIPTION
- Additional view menu now displaying name of views and will go to the directly
- You can go back to default view by clickin on default
- Additional view taking full space of content view and hiding the table selector 
- Url is updated when an additional view is clicked
- Updated custom template in sampledata.sql

To test the update use the following custom templates:

for contact table
[contact_customview.txt](https://github.com/WillTrem/UInnovate/files/14766140/contact_customview.txt)
for company table
[company_customview.txt](https://github.com/WillTrem/UInnovate/files/14766141/company_customview.txt)
[company_customview_tan.txt](https://github.com/WillTrem/UInnovate/files/14766142/company_customview_tan.txt)

![customView_data_navigation](https://github.com/WillTrem/UInnovate/assets/10947924/c76c3b67-21f8-4c2b-a506-8e14aebebf8e)

Bug #322 is also fixed with this PR