### PR TITLE
323 bug state of i18n translations on edit mode doesnt reset

### DIFF
--- a/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
@@ -330,9 +330,6 @@ const InternationalizationTab = () => {
         setSelectedLanguage(language);
         getTranslationsByLanguage(language);
 
-        //clear the translations when the language is changed
-        setTranslations([]);
-
         // Audits
         Audits.logAudits(
             loggedInUser || "",

--- a/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
@@ -541,7 +541,7 @@ const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslatio
     const [isEditingTranslation, setisEditingTranslation] = useState(false);
 
     const handleUpsertTranslation = async (languageCode: string, keyCode: string, newTranslation: string) => {
-        setisEditingTranslation(true);
+        // setisEditingTranslation(true);
         try {
             // Get the language and key IDs
             const languageId = await getLanguageId(languageCode);
@@ -571,9 +571,14 @@ const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslatio
         }
     }
     
-    const handleDoubleClick = () => {
+    const handleDoubleClickLabel = () => {
         if (!is_default && !isEditingLabel) {
             setisEditingLabel(true);
+        }
+    };
+    const handleDoubleClickTranslation = () => {
+        if  (!isEditingTranslation) {
+            setisEditingTranslation(true);
         }
     };
 
@@ -584,7 +589,7 @@ const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslatio
         }
     };
 
-    const handleTranslationBlur = () => {
+    const   handleTranslationBlur = () => {
         setisEditingTranslation(false);
         saveChangesTranslation();
     }
@@ -592,13 +597,13 @@ const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslatio
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         if (!is_default && isEditingLabel) {
             setEditedValue(e.target.value);
-            saveChangesLabel();
+            // saveChangesLabel();
         }
     };
 
     const handleTranslationCellChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setEditedTranslation(e.target.value);
-        saveChangesTranslation();
+        // saveChangesTranslation();
     }
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -699,14 +704,18 @@ const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslatio
 
     useEffect(() => {
         document.addEventListener("mousedown", handleClickOutside);
-        return () => {
-            document.removeEventListener("mousedown", handleClickOutside);
-        };
+        // return () => {
+        //     document.removeEventListener("mousedown", handleClickOutside);
+        // };
     }, []);
+
+    useEffect(() => {
+        setEditedTranslation(value);
+    }, [value])
 
     return (
         <tr>
-            <td onDoubleClick={handleDoubleClick} className="container-labels">
+            <td onDoubleClick={handleDoubleClickLabel} className="container-labels">
                 <input
                     value={isEditingLabel ? editedValue : keyCode}
                     onChange={handleChange}
@@ -753,9 +762,11 @@ const TranslationTableRow: React.FC<TranslationTableRowProps> = ({ getTranslatio
                 </Modal>
             </td>
 
-            <td onDoubleClick= {() => handleUpsertTranslation(selectedLanguage, keyCode || "", editedTranslation || "")}>                
+            <td onDoubleClick= {() => handleDoubleClickTranslation()
+                // handleUpsertTranslation(selectedLanguage, keyCode || "", editedTranslation || "")
+                }>                
                 <input
-                    value={isEditingTranslation ? editedTranslation : value}
+                    value={editedTranslation}
                     onChange={handleTranslationCellChange}  
                     onBlur={handleTranslationBlur}
                     onKeyDown={handleTranslationKeyDown}

--- a/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
+++ b/UInnovateApp/src/components/settingsPage/InternationalizationTab.tsx
@@ -323,6 +323,15 @@ const InternationalizationTab = () => {
     const handleSelectedNewLanguage = (event: SelectChangeEvent<string>) => {
         setNewLanguageName(event.target.value as string);
         setNewLanguageCode(isoLanguages.getCode(event.target.value as string));
+
+        // Audits
+        Audits.logAudits(
+            loggedInUser || "",
+            "Add New Language",
+            "Added language: " + "\"" + event.target.value + "\"",
+            "i18n_languages",
+            ""
+        );
     };
 
     const handleSelectedLanguage = (event: SelectChangeEvent<string>) => {
@@ -351,6 +360,15 @@ const InternationalizationTab = () => {
         } catch (error) {
             console.error('Error sorting by missing translations:', error);
         }
+
+        // Audits
+        Audits.logAudits(
+            loggedInUser || "",
+            "Sort by Missing Translations",
+            "Sorted by missing translations for the language: " + "\"" + selectedLanguage + "\"",
+            "i18n_translations",
+            ""
+        );
     };
 
 

--- a/UInnovateApp/src/styles/InternationalizationTab.css
+++ b/UInnovateApp/src/styles/InternationalizationTab.css
@@ -1,4 +1,4 @@
-div.default-language-input {
+div.selected-language-input {
     display: flex;
     flex-direction: row;
     width: 200px;


### PR DESCRIPTION
Previously there was a few bugs regarding editing translations and how the edit mode is triggered.
Check out #323 , to understand more the previous bug!

What is to be expected with this PR is to have no issues adding and editing translations and that the edit mode is triggered seamlessly.

There was a few Audits that were added:
- Adding Language
- Sorting by missing translations
- Selecting the language to be used with i18n

Some comments were removed and some variables got changed into a more proper way.
