### PR TITLE
276 foreign dropdown for Adding a Row 

### DIFF
--- a/UInnovateApp/src/components/AddRowPopup.tsx
+++ b/UInnovateApp/src/components/AddRowPopup.tsx
@@ -221,11 +221,12 @@ const AddRowPopup = ({
                         sx={selectStyle}
                         value={selectedValues[column.column_name] || -1}
                         onChange={handleSelectChange}
+                        data-testid="select-field"
                       >
 
 
                         <MenuItem value={-1} >None</MenuItem>
-                        
+
                         {displayField[count] && Rows && Rows[count] && Rows[count].map((row, index) => (
                           <MenuItem key={index} value={row[column.references_by]}>
                             {row[displayField[count]]}
@@ -239,6 +240,7 @@ const AddRowPopup = ({
                         name={column.column_name}
                         style={inputStyle}
                         onChange={handleInputChange}
+                        data-testid="input-field"
                       />
                     )}
                 </div>

--- a/UInnovateApp/src/components/AddRowPopup.tsx
+++ b/UInnovateApp/src/components/AddRowPopup.tsx
@@ -1,4 +1,12 @@
-import { Modal, Box, Typography, Button, Select, Menu, MenuItem } from "@mui/material";
+import {
+  Modal,
+  Box,
+  Typography,
+  Button,
+  Select,
+  Menu,
+  MenuItem,
+} from "@mui/material";
 import "../styles/AddEnumModal.css";
 import { useEffect, useRef, useState } from "react";
 import { DataAccessor, Row } from "../virtualmodel/DataAccessor";
@@ -25,7 +33,9 @@ const AddRowPopup = ({
   );
   const [displayField, setdisplayField] = useState<string[]>([]);
   const [Rows, setRows] = useState<Row[][] | undefined>([]);
-  const [selectedValues, setSelectedValues] = useState<Record<string, number>>({});
+  const [selectedValues, setSelectedValues] = useState<Record<string, number>>(
+    {}
+  );
   const selectCountRef = useRef(-1);
 
   useEffect(() => {
@@ -34,29 +44,29 @@ const AddRowPopup = ({
 
   // this is for the values of the foreign keys
   const getForeignKeys = async () => {
-
-
     const newDisplayFields = [];
     const newRows = [];
 
     for (const column of columns) {
-
-      if (column.references_table != null && column.references_table != "filegroup") {
+      if (
+        column.references_table != null &&
+        column.references_table != "filegroup"
+      ) {
         const schema = vmd.getTableSchema(column.references_table);
 
-
         if (!schema) {
-          console.error("Could not find schema for table ", column.references_table);
+          console.error(
+            "Could not find schema for table ",
+            column.references_table
+          );
           continue;
         }
 
-        const table = vmd.getTable(schema.schema_name, column.references_table)
-        if (!table) {
-          console.error("Could not find schema for table ", column.references_table);
-          continue;
-        }
 
-        const data_accessor: DataAccessor = vmd.getRowsDataAccessor(schema.schema_name, table.table_name);
+        const data_accessor: DataAccessor = vmd.getRowsDataAccessor(
+          schema.schema_name,
+          column.references_table
+        );
         const rows = await data_accessor.fetchRows();
 
         if (!rows) {
@@ -64,51 +74,46 @@ const AddRowPopup = ({
           continue;
         }
 
-        await vmd.getTableDisplayField(schema.schema_name, table.table_name);
-
-        const JSONdisplayField = JSON.parse(table.display_field);
-        const display_field = JSONdisplayField["displayField"];
-        newDisplayFields.push(display_field);
+        const display_field = await vmd.getTableDisplayField(schema.schema_name, column.references_table);
+        newDisplayFields.push(display_field as string);
         newRows.push(rows);
       }
     }
-  
+
     setdisplayField(newDisplayFields);
     setRows(newRows);
   };
 
-
-
-
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-
     setInputValues({
       ...inputValues,
       row: { ...inputValues.row, [e.target.name]: e.target.value },
     });
   };
 
-  const handleSelectChange = (e: React.ChangeEvent<{ name?: string; value: number }>) => {
-
+  const handleSelectChange = (
+    e: React.ChangeEvent<{ name?: string; value: number }>
+  ) => {
     const value = e.target.value;
     const name = e.target.name;
 
     setInputValues({
       ...inputValues,
-      row: { ...inputValues.row, [e.target.name as string]: e.target.value as unknown as string },
+      row: {
+        ...inputValues.row,
+        [e.target.name as string]: e.target.value as unknown as string,
+      },
     });
 
-    setSelectedValues(prevValues => ({ ...prevValues, [name as string]: value }));
-
+    setSelectedValues((prevValues) => ({
+      ...prevValues,
+      [name as string]: value,
+    }));
   };
 
-
-
-
   const handleFormSubmit = () => {
-
     const schema = vmd.getTableSchema(table.table_name);
-  
+
     if (!schema) {
       console.error("Could not find schema for table ", table.table_name);
       return;
@@ -118,7 +123,7 @@ const AddRowPopup = ({
       loggedInUser || "",
       "Add Row",
       "Added a new row with the following values: " +
-      JSON.stringify(inputValues.row),
+        JSON.stringify(inputValues.row),
       schema?.schema_name || "",
       table.table_name
     );
@@ -130,8 +135,8 @@ const AddRowPopup = ({
     );
     data_accessor.addRow();
 
-    getRows();
     onClose();
+    getRows();
   };
 
   const style = {
@@ -190,59 +195,55 @@ const AddRowPopup = ({
         )}
         <div className="addEnum">
           {columns.map((column: Column, idx) => {
-            if (column.references_table != null &&
-              column.references_table != "filegroup") {
-
-              selectCountRef.current += 1;
-            }
+            if (
+              column.references_table != null &&
+              column.references_table != "filegroup"
+            ) 
+            {selectCountRef.current += 1;}
             const count = selectCountRef.current % displayField.length;
             return (
               <div key={column.column_name} style={{ marginBottom: 10 }}>
-
                 <div style={{ display: "flex", alignItems: "center" }}>
-
                   <label key={idx} style={labelStyle}>
-
                     {column.references_table != null &&
-                      column.references_table != "filegroup"
+                    column.references_table != "filegroup"
                       ? column.references_table
                       : column.column_name}
-
                   </label>
                 </div>
                 <div>
-                  {column.references_table != null
-                    &&
-                    column.references_table != "filegroup"
-                    ?
-                    (
-                      <Select
-                        name={column.column_name}
-                        sx={selectStyle}
-                        value={selectedValues[column.column_name] || -1}
-                        onChange={handleSelectChange}
-                        data-testid="select-field"
-                      >
+                  {column.references_table != null &&
+                  column.references_table != "filegroup" ? (
+                    <Select
+                      name={column.column_name}
+                      sx={selectStyle}
+                      value={selectedValues[column.column_name] || -1}
+                      onChange={(handleSelectChange)}
+                      data-testid="select-field"
+                    >
+                      <MenuItem value={-1}>None</MenuItem>
 
-
-                        <MenuItem value={-1} >None</MenuItem>
-
-                        {displayField[count] && Rows && Rows[count] && Rows[count].map((row, index) => (
-                          <MenuItem key={index} value={row[column.references_by]}>
+                      {displayField[count] &&
+                        Rows &&
+                        Rows[count] &&
+                        Rows[count].map((row, index) => (
+                          <MenuItem
+                            key={index}
+                            value={row[column.references_by]}
+                          >
                             {row[displayField[count]]}
                           </MenuItem>
                         ))}
-
-                      </Select>
-                    ) : (
-                      <input
-                        type="text"
-                        name={column.column_name}
-                        style={inputStyle}
-                        onChange={handleInputChange}
-                        data-testid="input-field"
-                      />
-                    )}
+                    </Select>
+                  ) : (
+                    <input
+                      type="text"
+                      name={column.column_name}
+                      style={inputStyle}
+                      onChange={handleInputChange}
+                      data-testid="input-field"
+                    />
+                  )}
                 </div>
               </div>
             );
@@ -253,6 +254,7 @@ const AddRowPopup = ({
             variant="contained"
             onClick={handleFormSubmit}
             style={buttonStyle}
+            data-testid="submit-button"
           >
             Save Changes
           </Button>
@@ -261,7 +263,6 @@ const AddRowPopup = ({
           </Button>
         </div>
       </Box>
-
     </Modal>
   );
 };

--- a/UInnovateApp/src/components/AddRowPopup.tsx
+++ b/UInnovateApp/src/components/AddRowPopup.tsx
@@ -1,12 +1,13 @@
-import { Modal, Box, Typography, Button } from "@mui/material";
+import { Modal, Box, Typography, Button, Select } from "@mui/material";
 import "../styles/AddEnumModal.css";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DataAccessor, Row } from "../virtualmodel/DataAccessor";
 import vmd, { Column, Table } from "../virtualmodel/VMD";
 import Logger from "../virtualmodel/Logger";
-import { AuthState } from '../redux/AuthSlice';
-import { RootState } from '../redux/Store';
-import { useSelector } from 'react-redux';
+import { AuthState } from "../redux/AuthSlice";
+import { RootState } from "../redux/Store";
+import { useSelector } from "react-redux";
+import { use } from "chai";
 
 const AddRowPopup = ({
   onClose,
@@ -18,13 +19,31 @@ const AddRowPopup = ({
   columns: Column[];
 }) => {
   const [inputValues, setInputValues] = useState<Row>(new Row({}));
-  const {user: loggedInUser }: AuthState = useSelector((state: RootState) => state.auth);
+  const { user: loggedInUser }: AuthState = useSelector(
+    (state: RootState) => state.auth
+  );
+
+  useEffect(() => {
+    test();
+  }, [table]);
+
+
+  const test = () => {
+    console.log("columns", columns);
+  };
+
+
+
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValues({
       ...inputValues,
       row: { ...inputValues.row, [e.target.name]: e.target.value },
     });
   };
+
+
+
 
   const handleFormSubmit = () => {
     const schema = vmd.getTableSchema(table.table_name);
@@ -33,10 +52,11 @@ const AddRowPopup = ({
       return;
     }
 
-    Logger.logUserAction( 
+    Logger.logUserAction(
       loggedInUser || "",
       "Add Row",
-      "Added a new row with the following values: " + JSON.stringify(inputValues.row),
+      "Added a new row with the following values: " +
+        JSON.stringify(inputValues.row),
       schema?.schema_name || "",
       table.table_name
     );
@@ -48,7 +68,7 @@ const AddRowPopup = ({
     );
 
     data_accessor.addRow();
-    onClose();
+    onClose(); 
   };
 
   const style = {
@@ -61,9 +81,11 @@ const AddRowPopup = ({
     width: "auto",
     bgcolor: "#f1f1f1",
     border: "2px solid #000",
-    borderRadius: 8,
+    // borderRadius: 8,
     boxShadow: 24,
     p: 4,
+    maxHeight: "80vh",
+    overflow: "auto",
   };
 
   const labelStyle = {
@@ -101,15 +123,35 @@ const AddRowPopup = ({
           {columns.map((column: Column, idx) => {
             return (
               <div key={column.column_name} style={{ marginBottom: 10 }}>
-                <label key={idx} style={labelStyle}>
-                  {column.column_name}
-                  <input
-                    type="text"
-                    name={column.column_name}
-                    style={inputStyle}
-                    onChange={handleInputChange}
-                  />
-                </label>
+                <div style={{ display: "flex", alignItems: "center" }}>
+                  <label key={idx} style={labelStyle}>
+                    {column.references_table != null &&
+                    column.references_table != "filegroup"
+                      ? column.references_table
+                      : column.column_name}
+                  </label>
+                </div>
+                <div>
+                  {column.references_table != null 
+                  &&
+                  column.references_table != "filegroup" 
+                  ? 
+                  (
+                    <Select
+                      name={column.references_table}
+                      style={inputStyle}
+                    >
+                      
+                    </Select>
+                  ) : (
+                    <input
+                      type="text"
+                      name={column.column_name}
+                      style={inputStyle}
+                      onChange={handleInputChange}
+                    />
+                  )}
+                </div>
               </div>
             );
           })}

--- a/UInnovateApp/src/components/AddRowPopup.tsx
+++ b/UInnovateApp/src/components/AddRowPopup.tsx
@@ -62,7 +62,6 @@ const AddRowPopup = ({
           continue;
         }
 
-
         const data_accessor: DataAccessor = vmd.getRowsDataAccessor(
           schema.schema_name,
           column.references_table
@@ -74,7 +73,10 @@ const AddRowPopup = ({
           continue;
         }
 
-        const display_field = await vmd.getTableDisplayField(schema.schema_name, column.references_table);
+        const display_field = await vmd.getTableDisplayField(
+          schema.schema_name,
+          column.references_table
+        );
         newDisplayFields.push(display_field as string);
         newRows.push(rows);
       }
@@ -198,8 +200,9 @@ const AddRowPopup = ({
             if (
               column.references_table != null &&
               column.references_table != "filegroup"
-            ) 
-            {selectCountRef.current += 1;}
+            ) {
+              selectCountRef.current += 1;
+            }
             const count = selectCountRef.current % displayField.length;
             return (
               <div key={column.column_name} style={{ marginBottom: 10 }}>
@@ -218,7 +221,7 @@ const AddRowPopup = ({
                       name={column.column_name}
                       sx={selectStyle}
                       value={selectedValues[column.column_name] || -1}
-                      onChange={(handleSelectChange)}
+                      onChange={handleSelectChange}
                       data-testid="select-field"
                     >
                       <MenuItem value={-1}>None</MenuItem>
@@ -258,7 +261,12 @@ const AddRowPopup = ({
           >
             Save Changes
           </Button>
-          <Button variant="contained" onClick={onClose} style={buttonStyle}>
+          <Button 
+          variant="contained" 
+          onClick={onClose} 
+          style={buttonStyle}
+          data-testid="close-button"
+          >
             Close
           </Button>
         </div>

--- a/UInnovateApp/src/components/AddRowPopup.tsx
+++ b/UInnovateApp/src/components/AddRowPopup.tsx
@@ -187,6 +187,7 @@ const AddRowPopup = ({
       onClose={onClose}
       aria-labelledby="modal-modal-title"
       aria-describedby="modal-modal-description"
+      data-testid="modal-row-popup"
     >
       <Box sx={style}>
         {/* Verify if we need a modal for the Enum Type or the List Type to display the title */}
@@ -233,6 +234,7 @@ const AddRowPopup = ({
                           <MenuItem
                             key={index}
                             value={row[column.references_by]}
+                            data-testid="select-field-item"
                           >
                             {row[displayField[count]]}
                           </MenuItem>

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -697,56 +697,56 @@ const TableListView: React.FC<TableListViewProps> = ({
         // It's a single click
         handleOpenPanel(row);
       }
-      setClickAction(null);  
-    }, 200); 
+      setClickAction(null);
+    }, 200);
   };
 
-  const handleSave = async (e, rowIdx : number, columnName : string) => {
-      const confirmAction = async () => {
-        if (e.preventDefault) e.preventDefault();
-      
-        const newValue = e.target.value;
-        const updatedRow = { [columnName]: newValue };
-      
-        const schema = vmd.getTableSchema(table.table_name);
-        if (!schema) {
-          console.error("Schema not found");
-          return;
-        }
-      
-        Logger.logUserAction(
-          loggedInUser || "",
-          "Edited Cell",
-          `User has modified cell ${columnName} in row ${rowIdx}: from ${currentRow.row[columnName]} to ${newValue}`,
+  const handleSave = async (e, rowIdx: number, columnName: string) => {
+    const confirmAction = async () => {
+      if (e.preventDefault) e.preventDefault();
+
+      const newValue = e.target.value;
+      const updatedRow = { [columnName]: newValue };
+
+      const schema = vmd.getTableSchema(table.table_name);
+      if (!schema) {
+        console.error("Schema not found");
+        return;
+      }
+
+      Logger.logUserAction(
+        loggedInUser || "",
+        "Edited Cell",
+        `User has modified cell ${columnName} in row ${rowIdx}: from ${currentRow.row[columnName]} to ${newValue}`,
+        schema.schema_name,
+        table.table_name
+      );
+
+      const primaryKeyValue = Object.keys(currentRow.row)[0];
+      // Use the primary key for the row to identify which row to update
+      const storedPrimaryKeyValue = currentRow.row[primaryKeyValue];
+      // Call the update API
+      try {
+        const data_accessor: DataAccessor = vmd.getUpdateRowDataAccessorView(
           schema.schema_name,
-          table.table_name
+          table.table_name,
+          updatedRow,
+          primaryKeyValue as string,
+          storedPrimaryKeyValue as string
         );
-      
-        const primaryKeyValue = Object.keys(currentRow.row)[0];
-        // Use the primary key for the row to identify which row to update
-        const storedPrimaryKeyValue = currentRow.row[primaryKeyValue];
-        // Call the update API
-        try {
-          const data_accessor: DataAccessor = vmd.getUpdateRowDataAccessorView(
-            schema.schema_name,
-            table.table_name,
-            updatedRow,
-            primaryKeyValue as string,
-            storedPrimaryKeyValue as string
-          );
-          data_accessor.updateRow().then((res) => {
-            getRows();
-          });
-          // Reflect the update locally
-          const updatedRows = [...rows];
-          updatedRows[rowIdx] = new Row(updatedRow);
-          setRows(updatedRows);
-      
-          // Exit editing mode
-        } catch (error) {
-          console.error("Failed to update row", error);
-        }
-        setEditingCell(null);
+        data_accessor.updateRow().then((res) => {
+          getRows();
+        });
+        // Reflect the update locally
+        const updatedRows = [...rows];
+        updatedRows[rowIdx] = new Row(updatedRow);
+        setRows(updatedRows);
+
+        // Exit editing mode
+      } catch (error) {
+        console.error("Failed to update row", error);
+      }
+      setEditingCell(null);
     };
 
     setConfirmPopupContent({

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -1004,6 +1004,7 @@ const TableListView: React.FC<TableListViewProps> = ({
 
           {isPopupVisible && (
             <AddRowPopup
+              getRows={getRows}
               onClose={() => setIsPopupVisible(false)}
               table={table}
               columns={table.getColumns()}

--- a/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
+++ b/UInnovateApp/src/components/settingsPage/LookupSetting.tsx
@@ -24,7 +24,7 @@ const LookUpTableSetting: React.FC<LookUpTableProps> = ({ table }: LookUpTablePr
   const { user: loggedInUser }: AuthState = useSelector((state: RootState) => state.auth);
   attributes?.map((attribute) => {
     //checks for references table and referenced table
-    if (attribute.references_table != "null" && attribute.references_table != null) {
+    if (attribute.references_table != "null" && attribute.references_table != null && attribute.references_table != "filegroup") {
       count = count + 1;
       referencesTableList.push(attribute.references_table + ":references");
     }

--- a/UInnovateApp/src/tests/components/AddRowPopup.test.tsx
+++ b/UInnovateApp/src/tests/components/AddRowPopup.test.tsx
@@ -10,7 +10,19 @@ const mockTable = {
   table_display_type: "enum", // or "list"
 
 };
+const Col1 = new ColumnMock("Column1")
+const Col2 =new ColumnMock("Column2")
+Col1.setReferencesTable("i am not null")
+Col1.setReferencesBy("Ref_by")
 
+
+const mockCols= [
+  Col1, Col2
+]
+const table = new TableMock("example");
+
+table.addColumn(Col1)
+table.addColumn(Col2)
 
 const mockColumns = [
   {
@@ -18,9 +30,9 @@ const mockColumns = [
     column_type: "string",
     is_visible: true,
     reqOnCreate: true,
-    references_table: "",
+    references_table: null,
     is_editable: false,
-    references_by: "",
+    references_by: null,
     referenced_table: "",
     referenced_by: "",
   },
@@ -39,7 +51,6 @@ const mockColumns = [
   // Add more mock columns as needed
 ];
 
-const table = new TableMock("example");
 
 
 const onCloseMock = () => console.log("onCloseMock was called");
@@ -49,7 +60,7 @@ describe('AddRowPopup component', () => {
   it('renders the component with the correct title for enum type', async () => {
     render(
       <Provider store={store}>
-        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={mockTable} columns={mockColumns} />
+        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={mockTable} columns={mockCols} />
       </Provider>
     );
 
@@ -64,7 +75,7 @@ describe('AddRowPopup component', () => {
 
     render(
       <Provider store={store}>
-        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={mockTableListType} columns={mockColumns} />
+        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={mockTableListType} columns={mockCols} />
       </Provider>
     );
 
@@ -77,15 +88,19 @@ describe('AddRowPopup component', () => {
   it('renders input fields for each column', async () => {
     render(
       <Provider store={store}>
-        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={mockTable} columns={mockColumns} />
+        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={table} columns={mockColumns} />
       </Provider>
     );
-    const inputElement1 = screen.getByTestId("select-field");
+
+    const inputElement1 = screen.getByTestId("input-field");
     expect(inputElement1).toBeInTheDocument();
 
-    const inputElement = screen.getByTestId("input-field");
-    expect(inputElement).toBeInTheDocument();
+    const inputElement2 = screen.getByTestId("select-field");
+    expect(inputElement2).toBeInTheDocument();
 
-    
+  
+    // const inputElement = await screen.findByTestId("input-field");
+    // expect(inputElement).toBeInTheDocument();
+
   });
 });

--- a/UInnovateApp/src/tests/components/AddRowPopup.test.tsx
+++ b/UInnovateApp/src/tests/components/AddRowPopup.test.tsx
@@ -128,12 +128,11 @@ describe('AddRowPopup component', () => {
 
     const SelectInput = screen.getByTestId("select-field");
     expect(SelectInput).toBeInTheDocument();
+    await waitFor(() => {
+      expect(VMD.getRowsDataAccessor).toHaveBeenCalled();
+      expect(VMD.getTableSchema).toHaveBeenCalled();
+    });
     
-    act(() => SelectInput.click());
-    
-    const SelectFieldItems = screen.getAllByTestId("select-field-item");
-    expect(SelectFieldItems).toBeGreaterThanOrEqual(1);
-  
 
 
     const SubmitButton = screen.getByTestId("submit-button");

--- a/UInnovateApp/src/tests/components/AddRowPopup.test.tsx
+++ b/UInnovateApp/src/tests/components/AddRowPopup.test.tsx
@@ -1,62 +1,91 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, expect } from "vitest";
-import AddRowPopup from '../../components/AddRowPopup'; 
+import AddRowPopup from '../../components/AddRowPopup';
 import store from '../../redux/Store';
 import { Provider } from 'react-redux';
+import { ColumnMock, TableMock } from "../../virtualmodel/__mocks__/VMD";
 
 const mockTable = {
-    table_name: "mock_table",
-    table_display_type: "enum", // or "list"
-  };
-  
-  const mockColumns = [
-    { column_name: "Column1" },
-    { column_name: "Column2" },
-    // Add more mock columns as needed
-  ];
-  
-  const onCloseMock = () => console.log("onCloseMock was called");
-  
-  describe('AddRowPopup component', () => {
-    it('renders the component with the correct title for enum type', async () => {
-      render(
-        <Provider store={store}>
-        <AddRowPopup onClose={onCloseMock} table={mockTable} columns={mockColumns} />
-        </Provider>
-      );
-  
-      await waitFor(() => {
-        const titleElement = screen.getByText("Adding a new Enumerated type");
-        expect(titleElement).toBeInTheDocument();
-      });
-    });
-  
-    it('renders the component with the correct title for list type', async () => {
-      const mockTableListType = { ...mockTable, table_display_type: "list" };
-  
-      render(
-        <Provider store={store}>
-        <AddRowPopup onClose={onCloseMock} table={mockTableListType} columns={mockColumns} />
-        </Provider>
-      );
-  
-      await waitFor(() => {
-        const titleElement = screen.getByText("Adding a new List type");
-        expect(titleElement).toBeInTheDocument();
-      });
-    });
-  
-    it('renders input fields for each column', async () => {
-      render(
-        <Provider store={store}>
-        <AddRowPopup onClose={onCloseMock} table={mockTable} columns={mockColumns} />
-        </Provider>
-      );
-  
-      // Check if input fields are rendered for each column
-      mockColumns.forEach((column) => {
-        const inputElement = screen.getByLabelText(column.column_name);
-        expect(inputElement).toBeInTheDocument();
-      });
+  table_name: "mock_table",
+  table_display_type: "enum", // or "list"
+
+};
+
+
+const mockColumns = [
+  {
+    column_name: "column1",
+    column_type: "string",
+    is_visible: true,
+    reqOnCreate: true,
+    references_table: "",
+    is_editable: false,
+    references_by: "",
+    referenced_table: "",
+    referenced_by: "",
+  },
+
+  {
+    column_name: "column2",
+    column_type: "string",
+    is_visible: true,
+    reqOnCreate: true,
+    references_table: "Ref table",
+    is_editable: false,
+    references_by: "",
+    referenced_table: "",
+    referenced_by: ""
+  },
+  // Add more mock columns as needed
+];
+
+const table = new TableMock("example");
+
+
+const onCloseMock = () => console.log("onCloseMock was called");
+const getRowsMock = () => console.log("getRowsMock was called");
+
+describe('AddRowPopup component', () => {
+  it('renders the component with the correct title for enum type', async () => {
+    render(
+      <Provider store={store}>
+        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={mockTable} columns={mockColumns} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      const titleElement = screen.getByText("Adding a new Enumerated type");
+      expect(titleElement).toBeInTheDocument();
     });
   });
+
+  it('renders the component with the correct title for list type', async () => {
+    const mockTableListType = { ...mockTable, table_display_type: "list" };
+
+    render(
+      <Provider store={store}>
+        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={mockTableListType} columns={mockColumns} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      const titleElement = screen.getByText("Adding a new List type");
+      expect(titleElement).toBeInTheDocument();
+    });
+  });
+
+  it('renders input fields for each column', async () => {
+    render(
+      <Provider store={store}>
+        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={mockTable} columns={mockColumns} />
+      </Provider>
+    );
+    const inputElement1 = screen.getByTestId("select-field");
+    expect(inputElement1).toBeInTheDocument();
+
+    const inputElement = screen.getByTestId("input-field");
+    expect(inputElement).toBeInTheDocument();
+
+    
+  });
+});

--- a/UInnovateApp/src/tests/components/AddRowPopup.test.tsx
+++ b/UInnovateApp/src/tests/components/AddRowPopup.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect } from "vitest";
 import AddRowPopup from '../../components/AddRowPopup';
 import store from '../../redux/Store';
 import { Provider } from 'react-redux';
-import { ColumnMock, TableMock } from "../../virtualmodel/__mocks__/VMD";
+import VMD, { ColumnMock, TableMock } from "../../virtualmodel/__mocks__/VMD";
+import { Close } from '@mui/icons-material';
 
 const mockTable = {
   table_name: "mock_table",
@@ -85,22 +86,44 @@ describe('AddRowPopup component', () => {
     });
   });
 
-  it('renders input fields for each column', async () => {
+  it('renders input fields and select field and when submit is clicked ', async () => {
     render(
       <Provider store={store}>
         <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={table} columns={mockColumns} />
       </Provider>
     );
+    await waitFor(() => expect(VMD.getTableDisplayField).toHaveBeenCalled());
 
-    const inputElement1 = screen.getByTestId("input-field");
-    expect(inputElement1).toBeInTheDocument();
+    const inputElement = screen.getByTestId("input-field");
+    expect(inputElement).toBeInTheDocument();
 
-    const inputElement2 = screen.getByTestId("select-field");
-    expect(inputElement2).toBeInTheDocument();
+    const SelectInput = screen.getByTestId("select-field");
+    expect(SelectInput).toBeInTheDocument();
 
-  
-    // const inputElement = await screen.findByTestId("input-field");
-    // expect(inputElement).toBeInTheDocument();
+    const SubmitButton = screen.getByTestId("submit-button");
+    expect(SubmitButton).toBeInTheDocument();
+    act(() => SubmitButton.click());
+
+    await waitFor(() => expect(VMD.getAddRowDataAccessor).toHaveBeenCalled());
+    const modal = screen.queryByTestId("modal-row-popup");
+    expect(modal).toBeNull();
 
   });
+
+  it('renders only input fields and when close button is clicked', async () => {
+    render(
+      <Provider store={store}>
+        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={table} columns={mockCols} />
+      </Provider>
+    );
+    const inputElements = screen.getAllByTestId("input-field");
+    expect(inputElements).toHaveLength(2);
+    const CloseButton = screen.getByTestId("close-button");
+    expect(CloseButton).toBeInTheDocument(); 
+    act(() => CloseButton.click());
+
+    const modal = screen.queryByTestId("modal-row-popup");
+    expect(modal).toBeNull();
+    //modal-row-popup
+    });
 });

--- a/UInnovateApp/src/tests/components/AddRowPopup.test.tsx
+++ b/UInnovateApp/src/tests/components/AddRowPopup.test.tsx
@@ -52,16 +52,45 @@ const mockColumns = [
   // Add more mock columns as needed
 ];
 
+const mockColumns2 = [
+  {
+    column_name: "column1",
+    column_type: "string",
+    is_visible: true,
+    reqOnCreate: true,
+    references_table: null,
+    is_editable: false,
+    references_by: null,
+    referenced_table: "",
+    referenced_by: "",
+  },
+
+  {
+    column_name: "column2",
+    column_type: "string",
+    is_visible: true,
+    reqOnCreate: true,
+    references_table: "filegroup",
+    is_editable: false,
+    references_by: "",
+    referenced_table: "",
+    referenced_by: ""
+  },
+  // Add more mock columns as needed
+];
 
 
-const onCloseMock = () => console.log("onCloseMock was called");
-const getRowsMock = () => console.log("getRowsMock was called");
+
+
+const getRows = vi.fn();
+const onClose = vi.fn();
+
 
 describe('AddRowPopup component', () => {
   it('renders the component with the correct title for enum type', async () => {
     render(
       <Provider store={store}>
-        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={mockTable} columns={mockCols} />
+        <AddRowPopup getRows={getRows} onClose={onClose} table={mockTable} columns={mockCols} />
       </Provider>
     );
 
@@ -76,7 +105,7 @@ describe('AddRowPopup component', () => {
 
     render(
       <Provider store={store}>
-        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={mockTableListType} columns={mockCols} />
+        <AddRowPopup getRows={getRows} onClose={onClose} table={mockTableListType} columns={mockCols} />
       </Provider>
     );
 
@@ -89,7 +118,7 @@ describe('AddRowPopup component', () => {
   it('renders input fields and select field and when submit is clicked ', async () => {
     render(
       <Provider store={store}>
-        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={table} columns={mockColumns} />
+        <AddRowPopup getRows={getRows} onClose={onClose} table={table} columns={mockColumns} />
       </Provider>
     );
     await waitFor(() => expect(VMD.getTableDisplayField).toHaveBeenCalled());
@@ -99,21 +128,31 @@ describe('AddRowPopup component', () => {
 
     const SelectInput = screen.getByTestId("select-field");
     expect(SelectInput).toBeInTheDocument();
+    
+    act(() => SelectInput.click());
+    
+    const SelectFieldItems = screen.getAllByTestId("select-field-item");
+    expect(SelectFieldItems).toBeGreaterThanOrEqual(1);
+  
+
 
     const SubmitButton = screen.getByTestId("submit-button");
     expect(SubmitButton).toBeInTheDocument();
     act(() => SubmitButton.click());
-
-    await waitFor(() => expect(VMD.getAddRowDataAccessor).toHaveBeenCalled());
-    const modal = screen.queryByTestId("modal-row-popup");
-    expect(modal).toBeNull();
+    await waitFor(() => {
+      expect(VMD.getAddRowDataAccessor).toHaveBeenCalled();
+      expect(getRows).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+    
+   
 
   });
 
   it('renders only input fields and when close button is clicked', async () => {
     render(
       <Provider store={store}>
-        <AddRowPopup getRows={getRowsMock} onClose={onCloseMock} table={table} columns={mockCols} />
+        <AddRowPopup getRows={getRows} onClose={onClose} table={table} columns={mockColumns2} />
       </Provider>
     );
     const inputElements = screen.getAllByTestId("input-field");
@@ -122,8 +161,8 @@ describe('AddRowPopup component', () => {
     expect(CloseButton).toBeInTheDocument(); 
     act(() => CloseButton.click());
 
-    const modal = screen.queryByTestId("modal-row-popup");
-    expect(modal).toBeNull();
-    //modal-row-popup
+    expect(onClose).toHaveBeenCalled();
+
+    
     });
 });

--- a/UInnovateApp/src/virtualmodel/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/VMD.tsx
@@ -152,7 +152,6 @@ class VirtualModelDefinition {
     console.log(this.schemas);
   }
 
-
   // Method to get the display field for a table
   // return type : string
   async getTableDisplayField(schema_name: string, table_name: string) {
@@ -164,9 +163,9 @@ class VirtualModelDefinition {
       });
 
       const data = response.data;
-
+      let display_field = "";
       data.forEach((data: DisplayField) => {
-        if(data.schema === schema_name && data.table === table_name) {
+        if (data.schema === schema_name && data.table === table_name) {
           const schema = this.getSchema(data.schema);
 
           if (!schema) {
@@ -175,14 +174,18 @@ class VirtualModelDefinition {
           }
 
           const table = schema.getTable(data.table);
-          
+
           if (!table) {
-            console.error(`Table ${data.table} does not exist in schema ${data.schema}.`);
+            console.error(
+              `Table ${data.table} does not exist in schema ${data.schema}.`
+            );
             return;
           }
-          table.setDisplayField(data.display_field);
+          const JSONdisplayField = JSON.parse(data.display_field);
+          display_field = JSONdisplayField["displayField"];
         }
       });
+      return display_field;
     } catch (error) {
       console.error("Error:", error);
     }
@@ -916,7 +919,7 @@ export class Column {
   is_editable: boolean;
   references_by: string;
   referenced_table: string;
-  referenced_by:string;
+  referenced_by: string;
 
   constructor(column_name: string) {
     this.column_name = column_name;

--- a/UInnovateApp/src/virtualmodel/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/VMD.tsx
@@ -159,22 +159,22 @@ class VirtualModelDefinition {
     const table_url = API_BASE_URL + "tables";
 
     try {
-      let response = await axiosCustom.get(table_url, {
+      const response = await axiosCustom.get(table_url, {
         headers: { "Accept-Profile": "meta" },
       });
 
-      let data = response.data;
+      const data = response.data;
 
       data.forEach((data: DisplayField) => {
         if(data.schema === schema_name && data.table === table_name) {
-          let schema = this.getSchema(data.schema);
+          const schema = this.getSchema(data.schema);
 
           if (!schema) {
             console.error(`Schema ${data.schema} does not exist.`);
             return;
           }
 
-          let table = schema.getTable(data.table);
+          const table = schema.getTable(data.table);
           
           if (!table) {
             console.error(`Table ${data.table} does not exist in schema ${data.schema}.`);

--- a/UInnovateApp/src/virtualmodel/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/VMD.tsx
@@ -152,6 +152,42 @@ class VirtualModelDefinition {
     console.log(this.schemas);
   }
 
+
+  // Method to get the display field for a table
+  // return type : string
+  async getTableDisplayField(schema_name: string, table_name: string) {
+    const table_url = API_BASE_URL + "tables";
+
+    try {
+      let response = await axiosCustom.get(table_url, {
+        headers: { "Accept-Profile": "meta" },
+      });
+
+      let data = response.data;
+
+      data.forEach((data: DisplayField) => {
+        if(data.schema === schema_name && data.table === table_name) {
+          let schema = this.getSchema(data.schema);
+
+          if (!schema) {
+            console.error(`Schema ${data.schema} does not exist.`);
+            return;
+          }
+
+          let table = schema.getTable(data.table);
+          
+          if (!table) {
+            console.error(`Table ${data.table} does not exist in schema ${data.schema}.`);
+            return;
+          }
+          table.setDisplayField(data.display_field);
+        }
+      });
+    } catch (error) {
+      console.error("Error:", error);
+    }
+  }
+
   // Method to fetch schemas, tables, columns and views from the API
   // return type : void
   async fetchSchemas() {
@@ -705,6 +741,7 @@ export class Table {
   lookup_tables: string;
   stand_alone_details_view: boolean;
   lookup_counter: string;
+  display_field: string;
 
   constructor(table_name: string) {
     this.table_name = table_name;
@@ -716,6 +753,7 @@ export class Table {
     this.lookup_tables = "null";
     this.stand_alone_details_view = false;
     this.lookup_counter = "0";
+    this.display_field = "";
   }
 
   // Method to add a new column to the table object
@@ -861,6 +899,12 @@ export class Table {
   setLookupCounter(lookup_counter: string) {
     this.lookup_counter = lookup_counter;
   }
+
+  // Method to set the table's display field
+  // return type : void
+  setDisplayField(display_field: string) {
+    this.display_field = display_field;
+  }
 }
 
 export class Column {
@@ -983,6 +1027,13 @@ interface ColumnData {
 interface ViewData {
   schema: string;
   view: string;
+}
+
+// Defining DisplayField interface for type checking when calling /tables with the API
+interface DisplayField {
+  schema: string;
+  table: string;
+  display_field: string;
 }
 
 // Defining ConfigData interface for type checking when calling /appconfig_values with the API

--- a/UInnovateApp/src/virtualmodel/__mocks__/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/__mocks__/VMD.tsx
@@ -77,6 +77,12 @@ export default {
       console.log("getFunctionAccessor in VMD mock was called");
       return new FunctionAccessorMock(function_name);
     }),
+
+  getTableDisplayField: vi.fn().mockImplementation(() => {
+    console.log("getTableDisplayField in VMD mock was called");
+    return new TableMock("display_field");
+  }),
+
   getViewRowDataAccessor: vi
     .fn()
     .mockImplementation(

--- a/UInnovateApp/src/virtualmodel/__mocks__/VMD.tsx
+++ b/UInnovateApp/src/virtualmodel/__mocks__/VMD.tsx
@@ -80,7 +80,7 @@ export default {
 
   getTableDisplayField: vi.fn().mockImplementation(() => {
     console.log("getTableDisplayField in VMD mock was called");
-    return new TableMock("display_field");
+    return "display_field";
   }),
 
   getViewRowDataAccessor: vi
@@ -200,4 +200,21 @@ export class ColumnMock extends Column {
     console.log("setVisibility in Column mock was called");
     super.setVisibility(true);
   });
+  getReferencesTable = vi.fn().mockImplementation(() => {
+    console.log("getReferencesTable in Column mock was called");
+    return "references_table";
+  });
+  setReferencesTable = vi.fn().mockImplementation((references_table: string) => {
+    console.log("setReferencesTable in Column mock was called");
+    super.setReferenceTable(references_table);
+  });
+  getReferencesBy = vi.fn().mockImplementation(() => {
+    console.log("getReferencesBy in Column mock was called");
+    return "references_by";
+  });
+  setReferencesBy = vi.fn().mockImplementation((references_by: string) => {
+    console.log("setReferencesBy in Column mock was called");
+    super.setReferencesBy(references_by);
+  });
+
 }

--- a/database/useCase1/structure.sql
+++ b/database/useCase1/structure.sql
@@ -91,7 +91,7 @@ CREATE TABLE app_rentals.contact (
     email text,
     active boolean
 );
-COMMENT ON TABLE app_rentals.contact IS '{"displayField": "fullname"}';
+COMMENT ON TABLE app_rentals.contact IS '{"displayField": "full_name"}';
 COMMENT ON COLUMN app_rentals.contact.company_id IS '{"reqOnCreate": true, "refTable": "app_rentals.company"}';
 COMMENT ON COLUMN app_rentals.contact.first_name IS '{"reqOnCreate": true}';
 COMMENT ON COLUMN app_rentals.contact.last_name IS '{"reqOnCreate": true}';


### PR DESCRIPTION
## Major Changes

- When adding a row, for columns that are set with foreign keys from other tables, there is now a dropdown that shows the display field preferenced data by that foreign key table. 

For example:
Let's say we add a table, for Contact: 
![image](https://github.com/WillTrem/UInnovate/assets/92006009/90ba948c-a3d9-46c8-9e91-8a33c7422e1d)

For column company_id it now says Company as its label to show what table its foreign key is from. The Select now displays all the rows from the display field column of the table. So, in this case, it is the column "Company_name" since that's the comment on the table "Company". 
![image](https://github.com/WillTrem/UInnovate/assets/92006009/40360faa-a7b4-4730-83af-a27162cb7a99)

Now the selected will store it as a number, for when we save it in the Row. 



