### PR TITLE
331 weak tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,3 +312,11 @@ Note; this can take up to a few minutes the first time, it's normal.
 
 5. Visit localhost:8080 to see Postgoat container running on your local machine.
 
+## Diversity Statement
+At UInnovate, we believe:
+- That diversity comes in many different forms which we welcome 
+- In having an environment where anyone can contribute their talents and ideas into the project
+- In the importance of your data being safe and secure from outside breaches
+- That while using our software, your data will retain its confidentiality and integrity
+
+

--- a/UInnovateApp/src/components/TableListView.tsx
+++ b/UInnovateApp/src/components/TableListView.tsx
@@ -282,11 +282,9 @@ const TableListView: React.FC<TableListViewProps> = ({
       const allColumnsAreEditable = table.columns.every(
         (column) => column.is_editable === true
       );
-      console.log(allColumnsAreEditable)
       if (allColumnsAreEditable) {
         table.columns.forEach((column) => {
           if (column.references_table != null && column.references_table != "filegroup") {
-            console.log(column.column_name)
             column.setEditability(false);
           }
         });
@@ -609,7 +607,6 @@ const TableListView: React.FC<TableListViewProps> = ({
         storedPrimaryKeyValues
 
       );
-      console.log(data_accessor)
       data_accessor.updateRow().then(() => {
         getRows();
       });
@@ -1149,16 +1146,17 @@ const TableListView: React.FC<TableListViewProps> = ({
     if (!table.has_details_view) {
       return;
     }
-    if (!table.stand_alone_details_view) {
-      console.log("No Stand Alone Details View " + table.table_name);
-    }
+    
     const schema = vmd.getTableSchema(table.table_name);
     let detailtype = "overlay";
     if (table.stand_alone_details_view) {
       detailtype = "standalone";
     }
+    const firstNonEditableColumn = table.columns.find(column => !column.is_editable);
+    
+    const firstNonEditableColumnName = firstNonEditableColumn?.column_name;
     navigate(
-      `/${schema?.schema_name.toLowerCase()}/${table.table_name.toLowerCase()}/${row.row[table.table_name + "_id"]
+      `/${schema?.schema_name.toLowerCase()}/${table.table_name.toLowerCase()}/${row.row[firstNonEditableColumnName ?? '']
       }?details=${detailtype}`
     );
     setOpenPanel(true);


### PR DESCRIPTION
Fixed bug #331, 
now for tables with no direct primary key, it'll rely on its foreign keys for editing in the detail view. 

test with quotation_line_item and purchase order_line, now its foreign keys should be read-only, and when it updates it should use its multiple foreign keys in the API call
 

as well I added the diversity statement in the readme
  
